### PR TITLE
Expose the CPU profiler on the V8Runtime

### DIFF
--- a/ClearScript/V8/ClearScriptV8/NativePlatform.h
+++ b/ClearScript/V8/ClearScriptV8/NativePlatform.h
@@ -17,3 +17,4 @@
 #include <chrono>
 #include <condition_variable>
 #include <mutex>
+#include <sstream>

--- a/ClearScript/V8/ClearScriptV8/V8Isolate.h
+++ b/ClearScript/V8/ClearScriptV8/V8Isolate.h
@@ -35,6 +35,8 @@ public:
     virtual V8ScriptHolder* Compile(const V8DocumentInfo& documentInfo, const StdString& code, V8CacheType cacheType, const std::vector<std::uint8_t>& cacheBytes, bool& cacheAccepted) = 0;
     virtual void GetHeapInfo(V8IsolateHeapInfo& heapInfo) = 0;
     virtual void CollectGarbage(bool exhaustive) = 0;
+    virtual bool StartCpuProfiler(const StdString& title, bool recordSamples) = 0;
+    virtual StdString* StopCpuProfiler(const StdString& title) = 0;
 
     virtual ~V8Isolate() {}
 };

--- a/ClearScript/V8/ClearScriptV8/V8IsolateImpl.h
+++ b/ClearScript/V8/ClearScriptV8/V8IsolateImpl.h
@@ -364,6 +364,8 @@ public:
     virtual V8ScriptHolder* Compile(const V8DocumentInfo& documentInfo, const StdString& code, V8CacheType cacheType, const std::vector<std::uint8_t>& cacheBytes, bool& cacheAccepted) override;
     virtual void GetHeapInfo(V8IsolateHeapInfo& heapInfo) override;
     virtual void CollectGarbage(bool exhaustive) override;
+    virtual bool StartCpuProfiler(const StdString& title, bool recordSamples) override;
+    virtual StdString* StopCpuProfiler(const StdString& title) override;
 
     virtual void runMessageLoopOnPause(int contextGroupId) override;
     virtual void quitMessageLoopOnPause() override;
@@ -417,6 +419,7 @@ private:
 
     StdString m_Name;
     v8::Isolate* m_pIsolate;
+    v8::CpuProfiler* m_pProfiler;
     Persistent<v8::Private> m_hHostObjectHolderKey;
     RecursiveMutex m_Mutex;
     std::list<V8ContextImpl*> m_ContextPtrs;

--- a/ClearScript/V8/ClearScriptV8/V8IsolateProxyImpl.cpp
+++ b/ClearScript/V8/ClearScriptV8/V8IsolateProxyImpl.cpp
@@ -207,6 +207,32 @@ namespace V8 {
 
     //-------------------------------------------------------------------------
 
+    void V8IsolateProxyImpl::StartCpuProfiler(String^ gcTitle, bool recordSamples)
+    {
+        if (!GetIsolate()->StartCpuProfiler(StdString(gcTitle), recordSamples))
+        {
+            throw gcnew ScriptEngineException("The profiler could not be started");
+        }
+    }
+
+    //-------------------------------------------------------------------------
+
+    String^ V8IsolateProxyImpl::StopCpuProfiler(String^ gcTitle)
+    {
+        StdString* output = GetIsolate()->StopCpuProfiler(StdString(gcTitle));
+        if (output == nullptr)
+        {
+            throw gcnew ScriptEngineException("The profiler could not be stopped");
+        }
+
+        auto result = output->ToManagedString();
+        delete output;
+
+        return result;
+    }
+
+    //-------------------------------------------------------------------------
+
     SharedPtr<V8Isolate> V8IsolateProxyImpl::GetIsolate()
     {
         BEGIN_LOCK_SCOPE(m_gcLock)

--- a/ClearScript/V8/ClearScriptV8/V8IsolateProxyImpl.h
+++ b/ClearScript/V8/ClearScriptV8/V8IsolateProxyImpl.h
@@ -41,6 +41,8 @@ namespace V8 {
         virtual V8Script^ Compile(DocumentInfo documentInfo, String^ gcCode, V8CacheKind cacheKind, array<Byte>^ gcCacheBytes, [Out] Boolean% cacheAccepted) override;
         virtual V8RuntimeHeapInfo^ GetHeapInfo() override;
         virtual void CollectGarbage(bool exhaustive) override;
+        virtual void StartCpuProfiler(String ^gcTitle, bool recordSamples) override;
+        virtual String^ StopCpuProfiler(String ^gcTitle) override;
 
         SharedPtr<V8Isolate> GetIsolate();
 

--- a/ClearScript/V8/ClearScriptV8/V8Platform.h
+++ b/ClearScript/V8/ClearScriptV8/V8Platform.h
@@ -15,6 +15,7 @@
 #include "v8.h"
 #include "v8-platform.h"
 #include "v8-inspector.h"
+#include "v8-profiler.h"
 
 #pragma warning(pop)
 

--- a/ClearScript/V8/V8IsolateProxy.cs
+++ b/ClearScript/V8/V8IsolateProxy.cs
@@ -29,5 +29,8 @@ namespace Microsoft.ClearScript.V8
         public abstract V8RuntimeHeapInfo GetHeapInfo();
 
         public abstract void CollectGarbage(bool exhaustive);
+
+        public abstract void StartCpuProfiler(string title, bool recordSamples);
+        public abstract string StopCpuProfiler(string title);
     }
 }

--- a/ClearScript/V8/V8Runtime.cs
+++ b/ClearScript/V8/V8Runtime.cs
@@ -544,6 +544,24 @@ namespace Microsoft.ClearScript.V8
             proxy.CollectGarbage(exhaustive);
         }
 
+        /// <summary>
+        /// Starts a CPU profiler
+        /// </summary>
+        public void StartCpuProfiler(string title, bool recordSamples)
+        {
+            VerifyNotDisposed();
+            proxy.StartCpuProfiler(title ?? "", recordSamples);
+        }
+
+        /// <summary>
+        /// Stops a CPU profiler and returns the profile
+        /// </summary>
+        public string StopCpuProfiler(string title)
+        {
+            VerifyNotDisposed();
+            return proxy.StopCpuProfiler(title ?? "");
+        }
+
         #endregion
 
         #region internal members


### PR DESCRIPTION
This PR makes it possible to use the V8 CPU profiler with ClearScript. The StopCpuProfiler method returns a string that can be saved to a file and then imported into Chrome DevTools.

It has been a while since I last wrote any C++, but it seems to work.