### PR TITLE
Allow "Await Debugger" in V8 at any time, rather than just on startup

### DIFF
--- a/ClearScript/V8/V8ScriptEngine.cs
+++ b/ClearScript/V8/V8ScriptEngine.cs
@@ -693,6 +693,19 @@ namespace Microsoft.ClearScript.V8
         }
 
         /// <summary>
+        /// Specifies that the script engine is to wait for a debugger connection and schedule a
+        /// pause before executing the next application script. This method is
+        /// ignored if <see cref="V8ScriptEngineFlags.EnableDebugging"/> is not specified.
+        /// </summary>
+        public void AwaitDebuggerOnNextExecution()
+        {
+            if (engineFlags.HasFlag(V8ScriptEngineFlags.EnableDebugging))
+            {
+                awaitDebuggerAndPause = true;
+            }
+        }
+
+        /// <summary>
         /// Gets or sets the time interval between automatic CPU profile samples, in microseconds.
         /// </summary>
         /// <remarks>
@@ -713,7 +726,6 @@ namespace Microsoft.ClearScript.V8
                 proxy.CpuProfileSampleInterval = value;
             }
         }
-
         #endregion
 
         #region internal members


### PR DESCRIPTION
In our application we execute a lot of global/system scripts before we get to the "user" scripts, and most of the time its only those later scripts that we care about debugging, and normally only specific methods inside those user scripts, so pausing execution on startup is a little "heavy handed". Currently I am working around this by manually poking the flag in the V8ScriptEngine with reflection:

                    var field = engine.GetType().GetField("awaitDebuggerAndPause",
                        BindingFlags.NonPublic | BindingFlags.Instance);

                    field.SetValue(engine, true);

This works fine, but thought it would be nice to make this a supported thing to do, so this PR adds a single method to V8ScriptEngine that lets you set this flag on demand. Its a method rather than just setting the property directly because using a property setter feels like the caller has the responsibility to flip it back afterwards, but the script engine does that itself on next execution. 

I haven't added any tests for this because I couldn't see how (other than changing the visibility of the field, which felt icky), but its only a 3 line method so hopefully that's ok :)