### PR TITLE
Fix ToPromise not returning when faulted

### DIFF
--- a/ClearScript/JavaScript/JavaScriptExtensions.cs
+++ b/ClearScript/JavaScript/JavaScriptExtensions.cs
@@ -45,7 +45,7 @@ namespace Microsoft.ClearScript.JavaScript
             {
                 task.ContinueWith(thisTask =>
                 {
-                    if (thisTask.IsCompleted)
+                    if (thisTask.IsCompleted && !thisTask.IsCanceled && !thisTask.IsFaulted)
                     {
                         resolve(thisTask.Result);
                     }
@@ -87,7 +87,7 @@ namespace Microsoft.ClearScript.JavaScript
             {
                 task.ContinueWith(thisTask =>
                 {
-                    if (thisTask.IsCompleted)
+                    if (thisTask.IsCompleted && !thisTask.IsCanceled && !thisTask.IsFaulted)
                     {
                         resolve();
                     }


### PR DESCRIPTION
`ToPromise` was not properly calling `reject` when an exception was encountered.

## To reproduce the issue ##

```c#
using var engine = new V8ScriptEngine();
engine.AddHostType(typeof(Task));
engine.AddHostType(typeof(JavaScriptExtensions));

var throwError = new Func<Task>(() =>
{
    throw new Exception("Some error");
});
engine.AddHostObject("myFunc", throwError);

using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
cts.CancelAfter(TimeSpan.FromSeconds(10));

var tcs = new TaskCompletionSource<bool>();
cts.Token.Register(tcs.SetCanceled);

engine.Script.tcs = tcs;
engine.Execute(@"
(async function () {
    try {
        await myFunc().ToPromise();
        tcs.SetResult(true);
    } catch (err) {
        tcs.SetResult(false);
    }
})();");

var result = await tcs.Task;
// for me this times out every time
```
Adding a check to make sure neither `thisTask.IsCanceled` nor `thisTask.IsFaulted` are `true` before running `resolve` fixes this.