### PR TITLE
Async error handling

### DIFF
--- a/ClearScript/JavaScript/JavaScriptExtensions.cs
+++ b/ClearScript/JavaScript/JavaScriptExtensions.cs
@@ -1,102 +1,124 @@
-// Copyright (c) Microsoft Corporation. All rights reserved.
-// Licensed under the MIT license.
-
-using System.Threading.Tasks;
 using Microsoft.ClearScript.Util;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
 
-namespace Microsoft.ClearScript.JavaScript
+namespace Microsoft.ClearScript.Test
 {
-    /// <summary>
-    /// Defines extension methods for use with JavaScript engines.
-    /// </summary>
-    public static class JavaScriptExtensions
-    {
-        private delegate void Executor(dynamic resolve, dynamic reject);
+	/// <summary>
+	/// Defines extension methods for use with JavaScript engines.
+	/// </summary>
+	public static class JavaScriptExtensions
+	{
+		private delegate void Executor(dynamic resolve, dynamic reject);
 
-        /// <summary>
-        /// Converts a <see cref="Task{TResult}"/> instance to a
-        /// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
-        /// for use with script code currently running on the calling thread.
-        /// </summary>
-        /// <typeparam name="TResult">The task's result type.</typeparam>
-        /// <param name="task">The task to convert to a promise.</param>
-        /// <returns>A promise that represents the task's asynchronous operation.</returns>
-        public static object ToPromise<TResult>(this Task<TResult> task)
-        {
-            return task.ToPromise(ScriptEngine.Current);
-        }
+		/// <summary>
+		/// Converts a <see cref="Task{TResult}"/> instance to a
+		/// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
+		/// for use with script code currently running on the calling thread.
+		/// </summary>
+		/// <typeparam name="TResult">The task's result type.</typeparam>
+		/// <param name="task">The task to convert to a promise.</param>
+		/// <returns>A promise that represents the task's asynchronous operation.</returns>
+		public static object ToPromise<TResult>(this Task<TResult> task)
+		{
+			return task.ToPromise(ScriptEngine.Current);
+		}
 
-        /// <summary>
-        /// Converts a <see cref="Task{TResult}"/> instance to a
-        /// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
-        /// for use with script code running in the specified script engine.
-        /// </summary>
-        /// <typeparam name="TResult">The task's result type.</typeparam>
-        /// <param name="task">The task to convert to a promise.</param>
-        /// <param name="engine">The script engine in which the promise will be used.</param>
-        /// <returns>A promise that represents the task's asynchronous operation.</returns>
-        public static object ToPromise<TResult>(this Task<TResult> task, ScriptEngine engine)
-        {
-            MiscHelpers.VerifyNonNullArgument(task, "task");
-            MiscHelpers.VerifyNonNullArgument(engine, "engine");
+		/// <summary>
+		/// Converts a <see cref="Task{TResult}"/> instance to a
+		/// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
+		/// for use with script code running in the specified script engine.
+		/// </summary>
+		/// <typeparam name="TResult">The task's result type.</typeparam>
+		/// <param name="task">The task to convert to a promise.</param>
+		/// <param name="engine">The script engine in which the promise will be used.</param>
+		/// <returns>A promise that represents the task's asynchronous operation.</returns>
+		public static object ToPromise<TResult>(this Task<TResult> task, ScriptEngine engine)
+		{
+			MiscHelpers.VerifyNonNullArgument(task, "task");
+			MiscHelpers.VerifyNonNullArgument(engine, "engine");
 
-            var ctor = (ScriptObject)engine.Script.Promise;
-            return ctor.Invoke(true, new Executor((resolve, reject) =>
-            {
-                task.ContinueWith(thisTask =>
-                {
-                    if (thisTask.IsCompleted)
-                    {
-                        resolve(thisTask.Result);
-                    }
-                    else
-                    {
-                        reject(thisTask.Exception);
-                    }
-                }, TaskContinuationOptions.ExecuteSynchronously);
-            }));
-        }
+			var ctor = (ScriptObject)engine.Script.Promise;
+			return ctor.Invoke(true, new Executor((resolve, reject) =>
+			{
+				task.ContinueWith(thisTask =>
+				{
+					if (thisTask.IsCanceled) reject(thisTask);
+					else if (thisTask.IsFaulted) reject(thisTask);
+					else if (thisTask.IsCompleted) resolve(thisTask.Result);
+					else reject(thisTask);
+				}, TaskContinuationOptions.ExecuteSynchronously);
+			}));
+		}
 
-        /// <summary>
-        /// Converts a <see cref="Task"/> instance to a
-        /// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
-        /// for use with script code currently running on the calling thread.
-        /// </summary>
-        /// <param name="task">The task to convert to a promise.</param>
-        /// <returns>A promise that represents the task's asynchronous operation.</returns>
-        public static object ToPromise(this Task task)
-        {
-            return task.ToPromise(ScriptEngine.Current);
-        }
+		/// <summary>
+		/// Converts a <see cref="Task"/> instance to a
+		/// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
+		/// for use with script code currently running on the calling thread.
+		/// </summary>
+		/// <param name="task">The task to convert to a promise.</param>
+		/// <returns>A promise that represents the task's asynchronous operation.</returns>
+		public static object ToPromise(this Task task)
+		{
+			return task.ToPromise(ScriptEngine.Current);
+		}
 
-        /// <summary>
-        /// Converts a <see cref="Task"/> instance to a
-        /// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
-        /// for use with script code running in the specified script engine.
-        /// </summary>
-        /// <param name="task">The task to convert to a promise.</param>
-        /// <param name="engine">The script engine in which the promise will be used.</param>
-        /// <returns>A promise that represents the task's asynchronous operation.</returns>
-        public static object ToPromise(this Task task, ScriptEngine engine)
-        {
-            MiscHelpers.VerifyNonNullArgument(task, "task");
-            MiscHelpers.VerifyNonNullArgument(engine, "engine");
+		/// <summary>
+		/// Converts a <see cref="Task"/> instance to a
+		/// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
+		/// for use with script code running in the specified script engine.
+		/// </summary>
+		/// <param name="task">The task to convert to a promise.</param>
+		/// <param name="engine">The script engine in which the promise will be used.</param>
+		/// <returns>A promise that represents the task's asynchronous operation.</returns>
+		public static object ToPromise(this Task task, ScriptEngine engine)
+		{
+			MiscHelpers.VerifyNonNullArgument(task, "task");
+			MiscHelpers.VerifyNonNullArgument(engine, "engine");
 
-            var ctor = (ScriptObject)engine.Script.Promise;
-            return ctor.Invoke(true, new Executor((resolve, reject) =>
-            {
-                task.ContinueWith(thisTask =>
-                {
-                    if (thisTask.IsCompleted)
-                    {
-                        resolve();
-                    }
-                    else
-                    {
-                        reject(thisTask.Exception);
-                    }
-                }, TaskContinuationOptions.ExecuteSynchronously);
-            }));
-        }
-    }
+			var ctor = (ScriptObject)engine.Script.Promise;
+			return ctor.Invoke(true, new Executor((resolve, reject) =>
+			{
+				task.ContinueWith(thisTask =>
+				{
+					if (thisTask.IsCanceled) reject(thisTask);
+					else if (thisTask.IsFaulted) reject(thisTask);
+					else if (thisTask.IsCompleted) resolve();
+					else reject(thisTask);
+				}, TaskContinuationOptions.ExecuteSynchronously);
+			}));
+		}
+
+
+		/// <summary>
+		/// Converts a JavaScript promise instance into a Task
+		/// <see href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Promise">promise</see>
+		/// </summary>
+		/// <param name="promise">The promise to convert into a Task.</param>
+		/// <returns>A Task that represents the Promise's asynchronous operation.</returns>
+		public static Task<object> ToTask(this object promise)
+		{
+			var source = new TaskCompletionSource<object>();
+			((dynamic)promise).then(
+				new Action<object>(result => source.SetResult(result)),
+				new Action<dynamic>(rejected =>
+				{
+					var t = rejected as Task;
+					if (t != null)
+					{
+						if (t.IsCanceled) source.SetCanceled();
+						else if (t.Exception != null) source.SetException(t.Exception);
+					}
+					else
+					{
+						source.SetException(new Exception(rejected.ToString()));
+					}
+				})
+			);
+			return source.Task;
+		}
+
+	}
 }

--- a/ClearScriptTest/BugFixTest.cs
+++ b/ClearScriptTest/BugFixTest.cs
@@ -20,6 +20,7 @@ using Microsoft.CSharp.RuntimeBinder;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using Newtonsoft.Json;
 using UIAutomationClient;
+using System.Globalization;
 
 // ReSharper disable HeuristicUnreachableCode
 
@@ -1236,6 +1237,8 @@ namespace Microsoft.ClearScript.Test
         public void BugFix_DynamicMethodArgs()
         {
             engine.Script.foo = new DynamicMethodArgTest();
+            //Handle decimal points invariantly
+            Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
             Assert.AreEqual("123 456.789 hello", engine.Evaluate("foo.RunTest(123, 456.789, 'hello')"));
         }
 

--- a/ClearScriptTest/ClearScriptTest.csproj
+++ b/ClearScriptTest/ClearScriptTest.csproj
@@ -110,6 +110,7 @@
     </Compile>
     <Compile Include="PropertyBagTest.cs" />
     <Compile Include="MemberAccessTest.cs" />
+    <Compile Include="ToTaskExtensionTest.cs" />
     <Compile Include="V8ModuleTest.cs" />
     <Compile Include="StaticMemberAccessTest.cs" />
     <Compile Include="StaticTestClass.cs" />

--- a/ClearScriptTest/ToTaskExtensionTest.cs
+++ b/ClearScriptTest/ToTaskExtensionTest.cs
@@ -1,0 +1,392 @@
+﻿using Microsoft.ClearScript.V8;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Threading.Tasks;
+
+namespace Microsoft.ClearScript.Test
+{
+    [TestClass]
+    [DeploymentItem("ClearScriptV8-64.dll")]
+    [DeploymentItem("ClearScriptV8-32.dll")]
+    [DeploymentItem("v8-x64.dll")]
+    [DeploymentItem("v8-ia32.dll")]
+    [DeploymentItem("v8-base-x64.dll")]
+    [DeploymentItem("v8-base-ia32.dll")]
+    [DeploymentItem("v8-zlib-x64.dll")]
+    [DeploymentItem("v8-zlib-ia32.dll")]
+    [SuppressMessage("Microsoft.Design", "CA1001:TypesThatOwnDisposableFieldsShouldBeDisposable", Justification = "Test classes use TestCleanupAttribute for deterministic teardown.")]
+    public class ToTaskExtensionTest : ClearScriptTest
+    {
+        #region setup / teardown
+
+        private ScriptEngine _engine;
+        private TestTasks _testTasks;
+
+        [TestInitialize]
+        public void TestInitialize()
+        {
+            _engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
+            _engine.AddHostType(typeof(Extensions));
+            _engine.AddHostType(typeof(JavaScriptExtensions));
+            _engine.AddHostObject("Tracer", new Tracer());
+            _testTasks = new TestTasks(_engine.Script.Tracer);
+        }
+
+        [TestCleanup]
+        public void TestCleanup()
+        {
+            _engine.Dispose();
+            BaseTestCleanup();
+        }
+
+        #endregion
+
+        #region test methods
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_HandlesException_ThrowBeforeReturningPromise__WithJavaScriptExceptionHandler()
+        {
+            var setupScript = @"
+				var Test = {
+					throwBeforePromise: async function() {
+						try {
+							throw 'Throw before promise error';
+						} catch (error) {
+							Tracer.Log('JS Exception: ' + error);
+							throw error;
+						}
+					}
+				}
+			";
+            var evaluateFunction = "Test.throwBeforePromise();";
+            var expectedTrace = new[] {
+                "JS Exception: Throw before promise error",
+                "CLR Exception: Throw before promise error"
+            };
+
+            await RunTestScript(setupScript, evaluateFunction, expectedTrace);
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_HandlesException_ThrowInNonAsyncFunction()
+        {
+            var setupScript = @"
+				var Test = {
+					throwBeforePromise: function() {
+						throw 'Throw in non async function';
+					}
+				}
+			";
+            var evaluateFunction = "Test.throwBeforePromise();";
+            var expectedTrace = new[] {
+                "CLR Exception: Throw in non async function"
+            };
+
+            await RunTestScript(setupScript, evaluateFunction, expectedTrace);
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_HandlesException_ThrowInNonAsyncFunction_WithJavaScriptExceptionHandler()
+        {
+            var setupScript = @"
+				var Test = {
+					throwBeforePromise: function() {
+						try {
+							throw 'Throw before promise error';
+						} catch (error) {
+							Tracer.Log('JS Exception: ' + error);
+							throw error;
+						}
+					}
+				}
+			";
+            var evaluateFunction = "Test.throwBeforePromise();";
+            var expectedTrace = new[] {
+                "JS Exception: Throw before promise error",
+                "CLR Exception: Throw before promise error"
+            };
+
+            await RunTestScript(setupScript, evaluateFunction, expectedTrace);
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_HandlesExceptions_IntTask()
+        {
+            await RunTestScript(_engine,
+                _testTasks.GetIntTask(PointOfFailure.Canceled),
+                new[] { "A", "CLR Exception: A task was canceled." });
+            await RunTestScript(_engine,
+                _testTasks.GetIntTask(PointOfFailure.A),
+                new[] { "A", "CLR Exception: GetInt Fail A" });
+            await RunTestScript(_engine,
+                _testTasks.GetIntTask(PointOfFailure.B),
+                new[] { "A", "B", "CLR Exception: GetInt Fail B" });
+            await RunTestScript(_engine,
+                _testTasks.GetIntTask(PointOfFailure.C),
+                new[] { "A", "B", "C", "CLR Exception: GetInt Fail C" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_HandlesExceptions_IntTask_WithJavaScriptTryCatch()
+        {
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetIntTask(PointOfFailure.Canceled),
+                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: A task was canceled." });
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetIntTask(PointOfFailure.A),
+                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: GetInt Fail A" });
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetIntTask(PointOfFailure.B),
+                new[] { "A", "B", "JS Exception: [object HostObject]", "CLR Exception: GetInt Fail B" });
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetIntTask(PointOfFailure.C),
+                new[] { "A", "B", "C", "JS Exception: [object HostObject]", "CLR Exception: GetInt Fail C" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_HandlesExceptions_VoidTask()
+        {
+            await RunTestScript(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.Canceled),
+                new[] { "A", "CLR Exception: A task was canceled." });
+            await RunTestScript(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.A),
+                new[] { "A", "CLR Exception: GetVoid Fail A" });
+            await RunTestScript(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.B),
+                new[] { "A", "B", "CLR Exception: GetVoid Fail B" });
+            await RunTestScript(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.C),
+                new[] { "A", "B", "C", "CLR Exception: GetVoid Fail C" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_HandlesExceptions_VoidTask_WithJavaScriptTryCatch()
+        {
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.Canceled),
+                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: A task was canceled." });
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.A),
+                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: GetVoid Fail A" });
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.B),
+                new[] { "A", "B", "JS Exception: [object HostObject]", "CLR Exception: GetVoid Fail B" });
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.C),
+                new[] { "A", "B", "C", "JS Exception: [object HostObject]", "CLR Exception: GetVoid Fail C" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_ReturnsValue()
+        {
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.None),
+                new[] { "A", "B", "C", "CLR Result: [undefined]" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_ReturnsValue_IntTask()
+        {
+            await RunTestScript(_engine,
+                _testTasks.GetIntTask(PointOfFailure.None),
+                new[] { "A", "B", "C", "CLR Result: 10" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_ReturnsValue_IntTask_WithJavaScriptTryCatch()
+        {
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetIntTask(PointOfFailure.None),
+                new[] { "A", "B", "C", "CLR Result: 10" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_ReturnsValue_InvokingNonAsyncFunction()
+        {
+            _engine.Script.testDelegate = _testTasks.GetIntTask(PointOfFailure.None);
+            var setupScript = @"
+				var Test = {
+					notAsync: function() {
+						return testDelegate().ToPromise();
+					}
+				}
+			";
+            var evaluateFunction = "Test.notAsync();";
+            var expectedTrace = new[] { "A", "B", "C", "CLR Result: 10" };
+            await RunTestScript(setupScript, evaluateFunction, expectedTrace);
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_ReturnsValue_VoidTask()
+        {
+            await RunTestScript(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.None),
+                new[] { "A", "B", "C", "CLR Result: [undefined]" });
+        }
+
+        [TestMethod, TestCategory("ToTask")]
+        public async Task ToTask_ReturnsValue_VoidTask_WithJavaScriptTryCatch()
+        {
+            await RunTestScriptWithTryCatch(_engine,
+                _testTasks.GetVoidTask(PointOfFailure.None),
+                new[] { "A", "B", "C", "CLR Result: [undefined]" });
+        }
+
+        private async Task RunTestScript(string setupScript, string evaluateFunction, string[] expectedTrace)
+        {
+            var expectedTraceString = string.Join(Environment.NewLine, expectedTrace);
+            await RunTestScript(setupScript, evaluateFunction, expectedTraceString);
+        }
+
+        private async Task RunTestScript(string setupScript, string evaluateFunction, string expectedTraceString)
+        {
+            _engine.Script.Tracer.Clear();
+            try
+            {
+                _engine.Execute(setupScript);
+                var result = await _engine.Evaluate(evaluateFunction).ToTask();
+                _engine.Script.Tracer.Log("CLR Result: " + result);
+            }
+            catch (Exception ex)
+            {
+                _engine.Script.Tracer.Log("CLR Exception: " + GetInnerMostMessage(ex));
+            }
+
+            Assert.AreEqual(expectedTraceString, _engine.Script.Tracer.GetTrace());
+        }
+
+        private async Task RunTestScript(ScriptEngine engine, Delegate testDelegate, string[] expectedTrace)
+        {
+            engine.Script.testDelegate = testDelegate;
+            var setupScript = @"
+				var Test = {
+					getDelegate: async function() {
+						return await testDelegate().ToPromise();
+					},
+				}
+			";
+            var evaluateFunction = "Test.getDelegate();";
+
+            await RunTestScript(setupScript, evaluateFunction, expectedTrace);
+        }
+
+        private async Task RunTestScriptWithTryCatch(ScriptEngine engine, Delegate testDelegate, string[] expectedTrace)
+        {
+            engine.Script.testDelegate = testDelegate;
+            var setupScript = @"
+				var Test = {
+					getDelegate: async function() {
+						try {
+							return await testDelegate().ToPromise();
+						} catch (error) {
+							Tracer.Log('JS Exception: ' + error);
+							throw error;
+						}
+					},
+				}
+			";
+            var evaluateFunction = "Test.getDelegate();";
+
+            await RunTestScript(setupScript, evaluateFunction, expectedTrace);
+        }
+
+        #endregion
+
+        #region miscelaneous
+
+        public enum PointOfFailure { None, A, B, C, Canceled };
+
+        public class Tracer
+        {
+            private List<string> _trace = new List<string>();
+
+            public void Clear()
+            {
+                _trace.Clear();
+            }
+
+            public string GetTrace()
+            {
+                return string.Join(Environment.NewLine, _trace);
+            }
+
+            public void Log(object traceMessage)
+            {
+                _trace.Add(traceMessage.ToString());
+            }
+        }
+
+        // The exception handling tests below are using these test tasks with three failure points named A,B,C
+        //  The point of failures are as follows:
+        //	A - As soon as the task is started
+        //  ... simulated work ...
+        //	B - In the middle of continuations
+        //  ... simulated work ...
+        //	C - At the end of the continuations
+        //	+ an extra simulating When it's canceled
+        // 	I did not split these into individual tests, as code changes will likely affect all at once. (or maybe I'm just too lazy)
+        private class TestTasks
+        {
+            private Tracer _tracer;
+
+            public TestTasks(Tracer tracer)
+            {
+                _tracer = tracer;
+            }
+
+            public async Task Delay()
+            {
+                await Task.Delay(5);
+            }
+
+            public async Task<int> GetInt(PointOfFailure pof)
+            {
+                _tracer.Log("A");
+                if (pof == PointOfFailure.A) throw new Exception("GetInt Fail A");
+                await Delay();
+                if (pof == PointOfFailure.Canceled) throw new OperationCanceledException();
+                _tracer.Log("B");
+                if (pof == PointOfFailure.B) throw new Exception("GetInt Fail B");
+                await Delay();
+                _tracer.Log("C");
+                if (pof == PointOfFailure.C) throw new Exception("GetInt Fail C");
+                return 10;
+            }
+
+            public Delegate GetIntTask(PointOfFailure pof)
+            {
+                return new Func<Task<int>>(() => GetInt(pof));
+            }
+
+            public async Task GetVoid(PointOfFailure pof)
+            {
+                _tracer.Log("A");
+                if (pof == PointOfFailure.A) throw new Exception("GetVoid Fail A");
+                await Delay();
+                if (pof == PointOfFailure.Canceled) throw new OperationCanceledException();
+                _tracer.Log("B");
+                if (pof == PointOfFailure.B) throw new Exception("GetVoid Fail B");
+                await Delay();
+                _tracer.Log("C");
+                if (pof == PointOfFailure.C) throw new Exception("GetVoid Fail C");
+            }
+
+            public Delegate GetVoidTask(PointOfFailure pof)
+            {
+                return new Func<Task>(() => GetVoid(pof));
+            }
+        }
+
+        public static string GetInnerMostMessage(Exception ex)
+        {
+            return ex.InnerException == null
+                ? ex.Message
+                : GetInnerMostMessage(ex.InnerException);
+        }
+
+        #endregion
+    }
+}

--- a/ClearScriptTest/ToTaskExtensionTest.cs
+++ b/ClearScriptTest/ToTaskExtensionTest.cs
@@ -31,6 +31,7 @@ namespace Microsoft.ClearScript.Test
             _engine.AddHostType(typeof(Extensions));
             _engine.AddHostType(typeof(JavaScriptExtensions));
             _engine.AddHostObject("Tracer", new Tracer());
+            _engine.AddHostObject("GetInnerMostMessage", new Func<Exception, string>(GetInnerMostMessage));
             _testTasks = new TestTasks(_engine.Script.Tracer);
         }
 
@@ -46,7 +47,7 @@ namespace Microsoft.ClearScript.Test
         #region test methods
 
         [TestMethod, TestCategory("ToTask")]
-        public async Task ToTask_HandlesException_ThrowBeforeReturningPromise__WithJavaScriptExceptionHandler()
+        public async Task ToTask_HandlesException_ThrowBeforeReturningPromise_WithJavaScriptExceptionHandler()
         {
             var setupScript = @"
 				var Test = {
@@ -133,16 +134,16 @@ namespace Microsoft.ClearScript.Test
         {
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetIntTask(PointOfFailure.Canceled),
-                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: A task was canceled." });
+                new[] { "A", "JS Exception: A task was canceled.", "CLR Exception: A task was canceled." });
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetIntTask(PointOfFailure.A),
-                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: GetInt Fail A" });
+                new[] { "A", "JS Exception: GetInt Fail A", "CLR Exception: GetInt Fail A" });
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetIntTask(PointOfFailure.B),
-                new[] { "A", "B", "JS Exception: [object HostObject]", "CLR Exception: GetInt Fail B" });
+                new[] { "A", "B", "JS Exception: GetInt Fail B", "CLR Exception: GetInt Fail B" });
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetIntTask(PointOfFailure.C),
-                new[] { "A", "B", "C", "JS Exception: [object HostObject]", "CLR Exception: GetInt Fail C" });
+                new[] { "A", "B", "C", "JS Exception: GetInt Fail C", "CLR Exception: GetInt Fail C" });
         }
 
         [TestMethod, TestCategory("ToTask")]
@@ -167,16 +168,16 @@ namespace Microsoft.ClearScript.Test
         {
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetVoidTask(PointOfFailure.Canceled),
-                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: A task was canceled." });
+                new[] { "A", "JS Exception: A task was canceled.", "CLR Exception: A task was canceled." });
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetVoidTask(PointOfFailure.A),
-                new[] { "A", "JS Exception: [object HostObject]", "CLR Exception: GetVoid Fail A" });
+                new[] { "A", "JS Exception: GetVoid Fail A", "CLR Exception: GetVoid Fail A" });
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetVoidTask(PointOfFailure.B),
-                new[] { "A", "B", "JS Exception: [object HostObject]", "CLR Exception: GetVoid Fail B" });
+                new[] { "A", "B", "JS Exception: GetVoid Fail B", "CLR Exception: GetVoid Fail B" });
             await RunTestScriptWithTryCatch(_engine,
                 _testTasks.GetVoidTask(PointOfFailure.C),
-                new[] { "A", "B", "C", "JS Exception: [object HostObject]", "CLR Exception: GetVoid Fail C" });
+                new[] { "A", "B", "C", "JS Exception: GetVoid Fail C", "CLR Exception: GetVoid Fail C" });
         }
 
         [TestMethod, TestCategory("ToTask")]
@@ -282,7 +283,7 @@ namespace Microsoft.ClearScript.Test
 						try {
 							return await testDelegate().ToPromise();
 						} catch (error) {
-							Tracer.Log('JS Exception: ' + error);
+							Tracer.Log('JS Exception: ' + GetInnerMostMessage(error));
 							throw error;
 						}
 					},

--- a/NetCore/ClearScriptTest/ClearScriptTest.csproj
+++ b/NetCore/ClearScriptTest/ClearScriptTest.csproj
@@ -70,6 +70,7 @@
     <Compile Include="..\..\ClearScriptTest\StaticMemberAccessTest.cs" Link="StaticMemberAccessTest.cs" />
     <Compile Include="..\..\ClearScriptTest\StaticTestClass.cs" Link="StaticTestClass.cs" />
     <Compile Include="..\..\ClearScriptTest\TestObject.cs" Link="TestObject.cs" />
+    <Compile Include="..\..\ClearScriptTest\ToTaskExtensionTest.cs" Link="ToTaskExtensionTest.cs" />
     <Compile Include="..\..\ClearScriptTest\TypeRestrictionTest.cs" Link="TypeRestrictionTest.cs" />
     <Compile Include="..\..\ClearScriptTest\V8ArrayBufferOrViewTest.cs" Link="V8ArrayBufferOrViewTest.cs" />
     <Compile Include="..\..\ClearScriptTest\V8ModuleTest.cs" Link="V8ModuleTest.cs" />

--- a/V8Update.cmd
+++ b/V8Update.cmd
@@ -210,6 +210,7 @@ cd ..
 :CreatePatchesDone
 
 :Build32Bit
+setlocal
 echo Building 32-bit V8 ...
 cd v8
 call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall" x86 >nul
@@ -219,9 +220,11 @@ if errorlevel 1 goto Error
 ninja -C out\ia32\%mode% v8-ia32.dll >build-ia32.log
 if errorlevel 1 goto Error
 cd ..
+endlocal
 :Build32BitDone
 
 :Build64Bit
+setlocal
 echo Building 64-bit V8 ...
 cd v8
 call "%VSINSTALLDIR%\VC\Auxiliary\Build\vcvarsall" x64 >nul
@@ -231,6 +234,7 @@ if errorlevel 1 goto Error
 ninja -C out\x64\%mode% v8-x64.dll >build-x64.log
 if errorlevel 1 goto Error
 cd ..
+endlocal
 :Build64BitDone
 
 :BuildDone
@@ -302,6 +306,7 @@ echo Succeeded!
 goto Exit
 
 :Error
+endlocal
 echo *** THE PREVIOUS STEP FAILED ***
 
 :Exit


### PR DESCRIPTION
I needed the ToTask and ToPromise extensions to work well with error handling in most of the normal uses cases. So tried to mimic these in LinqPad, where I fixed some issues in the current implementation. It blocked the thread when exceptions was thrown. 

It was a small change, but it happened to be really hard to share it with a PR, as nothing worked out of the box on my machine.

### So a little story on that:
It might be a good idea to put some effort into the V8 build, as I almost gave up (and it's such a shame if it stops any people from contributing). My VS installation also needed a repair before it recognized the .net framework unit test project type - to be fair.

I was told that you are looking into shipping a pre-built V8 engine, which I think would remove all the hassle of getting started - should probably be a priority.

Anyway, the first two commits has only to do with getting the project up and running (and pass all tests). After cleaning up all my system/user paths to a bare minimum, and substituting the build path with a drive letter, it completed the 32 bit V8 build, but still failed on the 64 bit. I was told that some people have had success with setlocal/endlocal, so I added this - and it finally completed both builds. 

But it was to much of a struggle finding out the reasons, as you don't get clear and informative errors back (nature of batch commands) - you need to dig it out. But thanks for all the help I received, from the ClearScript maintainer(s). 

Depending on your VS installation, your Developer Command prompt might have a variable number of paths configured (it will add its own locations. to your system/user defined paths), The V8build.cmd is very dependent (fragile) on the total length of the paths, and if you see "line too long" errors, it's likely due to a path concatenation statement failing somewhere. I've also seen some "mysterious" Python errors (code 255), when it tries to read out the env variables, and I guess it's also caused by the same issue, as they went away with the other efforts.

**NB:** I tried to run all test using a C# language version 7.3 compilation (including my original code). It works exactly the same, so I don't see why you should stay on the old version, unless you have some other tooling that need's it.

I can submit a PR if you like - now that everything is finally running :-)