### PR TITLE
Fix error details from VBScript in some cases

### DIFF
--- a/ClearScript/Windows/WindowsScriptEngine.Site.cs
+++ b/ClearScript/Windows/WindowsScriptEngine.Site.cs
@@ -5,6 +5,7 @@ using System;
 using System.Diagnostics;
 using System.Globalization;
 using System.Linq;
+using Reflection = System.Reflection;
 using System.Runtime.InteropServices;
 using Microsoft.ClearScript.Util;
 using Microsoft.ClearScript.Util.COM;
@@ -197,7 +198,15 @@ namespace Microsoft.ClearScript.Windows
                             innerException = engine.CurrentScriptFrame.HostException;
                             if ((innerException != null) && string.IsNullOrWhiteSpace(description))
                             {
-                                description = innerException.Message;
+                                if (innerException is Reflection.TargetInvocationException &&
+                                    innerException.InnerException != null)
+                                {
+                                    description = innerException.InnerException.Message;
+                                }
+                                else
+                                {
+                                    description = innerException.Message;
+                                }
                             }
                         }
 
@@ -297,7 +306,15 @@ namespace Microsoft.ClearScript.Windows
                             innerException = engine.CurrentScriptFrame.HostException;
                             if ((innerException != null) && string.IsNullOrWhiteSpace(description))
                             {
-                                description = innerException.Message;
+                                if (innerException is Reflection.TargetInvocationException &&
+                                    innerException.InnerException != null)
+                                {
+                                    description = innerException.InnerException.Message;
+                                }
+                                else
+                                {
+                                    description = innerException.Message;
+                                }
                             }
                         }
 

--- a/ClearScript/Windows/WindowsScriptEngine.Site.cs
+++ b/ClearScript/Windows/WindowsScriptEngine.Site.cs
@@ -82,7 +82,12 @@ namespace Microsoft.ClearScript.Windows
                         Debug.Assert(false, "Exception caught during error processing", exception.ToString());
                     }
                 }
-
+                //If we don't have a debugger, at least try to report the location
+                var errorLocation2 = GetErrorLocation(error);
+                if (!string.IsNullOrWhiteSpace(errorLocation2))
+                {
+                    return message + "\n" + errorLocation2;
+                }
                 return message;
             }
 
@@ -116,6 +121,10 @@ namespace Microsoft.ClearScript.Windows
 
                         var text = new string(document.Code.Skip(position).TakeWhile(ch => ch != '\n').ToArray());
                         return MiscHelpers.FormatInvariant("    at ({0}:{1}:{2}) -> {3}", documentName, lineNumber, offsetInLine, text);
+                    }
+                    else
+                    {
+                        return MiscHelpers.FormatInvariant("    at (Unknown:{0}:{1})", lineNumber, offsetInLine);
                     }
                 }
 

--- a/ClearScript/Windows/WindowsScriptEngine.cs
+++ b/ClearScript/Windows/WindowsScriptEngine.cs
@@ -502,15 +502,15 @@ namespace Microsoft.ClearScript.Windows
 
         private void ThrowScriptError(Exception exception)
         {
+            if (CurrentScriptFrame.ScriptError != null || CurrentScriptFrame.PendingScriptError != null)
+            {
+                // a script error was reported; the corresponding exception should be in the script frame
+                ThrowScriptError(CurrentScriptFrame.ScriptError ?? CurrentScriptFrame.PendingScriptError);
+            }
             var comException = exception as COMException;
             if (comException != null)
             {
-                if (CurrentScriptFrame.ScriptError != null || CurrentScriptFrame.PendingScriptError != null)
-                {
-                    // a script error was reported; the corresponding exception should be in the script frame
-                    ThrowScriptError(CurrentScriptFrame.ScriptError ?? CurrentScriptFrame.PendingScriptError);
-                }
-                else if (comException.ErrorCode == HResult.CLEARSCRIPT_E_HOSTEXCEPTION)
+                if (comException.ErrorCode == HResult.CLEARSCRIPT_E_HOSTEXCEPTION)
                 {
                     // A host exception surrogate passed through the COM boundary; this happens
                     // when some script engines are invoked via script item access rather than

--- a/ClearScript/Windows/WindowsScriptEngine.cs
+++ b/ClearScript/Windows/WindowsScriptEngine.cs
@@ -505,7 +505,7 @@ namespace Microsoft.ClearScript.Windows
             var comException = exception as COMException;
             if (comException != null)
             {
-                if (comException.ErrorCode == HResult.SCRIPT_E_REPORTED)
+                if (CurrentScriptFrame.ScriptError != null || CurrentScriptFrame.PendingScriptError != null)
                 {
                     // a script error was reported; the corresponding exception should be in the script frame
                     ThrowScriptError(CurrentScriptFrame.ScriptError ?? CurrentScriptFrame.PendingScriptError);

--- a/ClearScriptTest/VBScriptEngineTest.cs
+++ b/ClearScriptTest/VBScriptEngineTest.cs
@@ -491,6 +491,28 @@ namespace Microsoft.ClearScript.Test
         }
 
         [TestMethod, TestCategory("VBScriptEngine")]
+        public void VBScriptEngine_ExceptionDetails2()
+        {
+            engine.AddHostObject("test", HostItemFlags.DirectAccess, new ComVisibleTestObject());
+            engine.Execute("Sub Run\ntest = \"invalid type\"\nEnd Sub");
+            try
+            {
+                engine.Invoke("Run");
+                Assert.Fail("Expected failure");
+            }
+            catch (ScriptEngineException see)
+            {
+                Assert.AreEqual(
+                    "Class doesn't support Automation: 'test'\n    at Run (Script [3]:1:0) -> test = \"invalid type\"",
+                    see.ErrorDetails, "Details message was wrong");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Wrong exception thrown: " + ex);
+            }
+        }
+
+        [TestMethod, TestCategory("VBScriptEngine")]
         public void VBScriptEngine_AccessContext_Private()
         {
             engine.AddHostObject("test", this);
@@ -3025,6 +3047,7 @@ namespace Microsoft.ClearScript.Test
         }
 
         [ComVisible(true)]
+        [ClassInterface(ClassInterfaceType.AutoDual)]
         public sealed class ComVisibleTestObject
         {
             public string Format(string format, object arg0 = null, object arg1 = null, object arg2 = null, object arg3 = null)
@@ -3036,6 +3059,8 @@ namespace Microsoft.ClearScript.Test
             {
                 return default(T);
             }
+         
+            public double Value { get; set; }
         }
 
         #endregion

--- a/ClearScriptTest/VBScriptEngineTest.cs
+++ b/ClearScriptTest/VBScriptEngineTest.cs
@@ -491,6 +491,30 @@ namespace Microsoft.ClearScript.Test
         }
 
         [TestMethod, TestCategory("VBScriptEngine")]
+        public void VBScriptEngine_ExceptionDetails_NoDebugger()
+        {
+            engine.Dispose();
+            engine = new VBScriptEngine(WindowsScriptEngineFlags.None);
+            engine.AddHostObject("test", this);
+            engine.Execute("Sub Run\ntest.NonExistent = 3\nEnd Sub");
+            try
+            {
+                engine.Invoke("Run");
+                Assert.Fail("Expected failure");
+            }
+            catch (ScriptEngineException see)
+            {
+                Assert.AreEqual(
+                   "Object doesn't support this property or method: 'test.NonExistent'\n    at (Unknown:1:0)",
+                   see.ErrorDetails, "Details message was wrong");
+            }
+            catch (Exception ex)
+            {
+                Assert.Fail("Wrong exception thrown: " + ex);
+            }
+        }
+
+        [TestMethod, TestCategory("VBScriptEngine")]
         public void VBScriptEngine_ExceptionDetails2()
         {
             engine.AddHostObject("test", HostItemFlags.DirectAccess, new ComVisibleTestObject());

--- a/ClearScriptTest/VBScriptEngineTest.cs
+++ b/ClearScriptTest/VBScriptEngineTest.cs
@@ -469,6 +469,28 @@ namespace Microsoft.ClearScript.Test
         }
 
         [TestMethod, TestCategory("VBScriptEngine")]
+        public void VBScriptEngine_ExceptionDetails()
+        {
+            engine.AddHostObject("test", this);
+            engine.Execute("Sub Run\ntest.NonExistent = 3\nEnd Sub");
+            try
+            {
+                engine.Invoke("Run");
+                Assert.Fail("Expected failure");
+            }
+            catch ( ScriptEngineException see )
+            {
+                Assert.AreEqual(
+                   "Object doesn't support this property or method: 'test.NonExistent'\n    at Run (Script [3]:1:0) -> test.NonExistent = 3",
+                   see.ErrorDetails, "Details message was wrong");
+            }
+            catch ( Exception ex )
+            {
+                Assert.Fail("Wrong exception thrown: " + ex);
+            }
+        }
+
+        [TestMethod, TestCategory("VBScriptEngine")]
         public void VBScriptEngine_AccessContext_Private()
         {
             engine.AddHostObject("test", this);


### PR DESCRIPTION
Fix a case where error details including the stack trace were not getting reported when they should. Also added a test case that proves that the error details in this case get reported correctly.

Note, error handling is quite complex in here, so I'm not 100% certain this is always the right thing to do. We also have some indication that the problem may be intermittent, though I haven't been able to prove that yet.