### PR TITLE
Fix fast up to date check

### DIFF
--- a/NetCore/ClearScript.Core/ClearScript.Core.csproj
+++ b/NetCore/ClearScript.Core/ClearScript.Core.csproj
@@ -163,14 +163,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="JavaScript\" />
-        <Folder Include="Properties\" />
-        <Folder Include="Util\COM\" />
-        <Folder Include="Util\Test\" />
-        <Folder Include="Util\Web\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="Microsoft.Win32.Registry" Version="4.7.0" />
     </ItemGroup>
 

--- a/NetCore/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetCore/ClearScript.V8/ClearScript.V8.csproj
@@ -73,12 +73,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-        <Folder Include="V8\" />
-        <Folder Include="V8\SplitProxy\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::IsOSPlatform($([System.Runtime.InteropServices.OSPlatform]::Windows)))' And ('$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X86' Or '$([System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture)'=='X64')" Include="..\..\bin\$(Configuration)\ClearScriptV8.win-x86.dll" Link="ClearScriptV8.win-x86.dll">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
             <Visible>false</Visible>

--- a/NetCore/ClearScript.Windows/ClearScript.Windows.csproj
+++ b/NetCore/ClearScript.Windows/ClearScript.Windows.csproj
@@ -53,11 +53,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-        <Folder Include="Windows\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
     </ItemGroup>
 

--- a/NetCore/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
+++ b/NetCore/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
@@ -26,10 +26,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\ClearScript.V8\ClearScript.V8.csproj" />
         <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />

--- a/NetCore/ClearScriptConsole/ClearScriptConsole.csproj
+++ b/NetCore/ClearScriptConsole/ClearScriptConsole.csproj
@@ -30,10 +30,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <PackageReference Include="MSTest.TestFramework" Version="2.1.2" />
     </ItemGroup>
 

--- a/NetCore/ClearScriptTest/ClearScriptTest.csproj
+++ b/NetCore/ClearScriptTest/ClearScriptTest.csproj
@@ -234,10 +234,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\ClearScript.V8\ClearScript.V8.csproj" />
         <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />

--- a/NetFramework/ClearScript.Core/ClearScript.Core.csproj
+++ b/NetFramework/ClearScript.Core/ClearScript.Core.csproj
@@ -167,15 +167,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Exports\" />
-        <Folder Include="JavaScript\" />
-        <Folder Include="Properties\" />
-        <Folder Include="Util\COM\" />
-        <Folder Include="Util\Test\" />
-        <Folder Include="Util\Web\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="..\..\ClearScript\DelegateFactory.tt" Link="DelegateFactory.tt">
             <Generator>TextTemplatingFileGenerator</Generator>
             <LastGenOutput>DelegateFactory.Generated.cs</LastGenOutput>

--- a/NetFramework/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetFramework/ClearScript.V8/ClearScript.V8.csproj
@@ -81,12 +81,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-        <Folder Include="V8\" />
-        <Folder Include="V8\SplitProxy\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="..\..\ClearScript\Properties\AssemblyInfo.V8.tt" Link="Properties\AssemblyInfo.V8.tt">
             <Generator>TextTemplatingFileGenerator</Generator>
             <LastGenOutput>AssemblyInfo.V8.cs</LastGenOutput>

--- a/NetFramework/ClearScript.Windows/ClearScript.Windows.csproj
+++ b/NetFramework/ClearScript.Windows/ClearScript.Windows.csproj
@@ -55,11 +55,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-        <Folder Include="Windows\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="..\..\ClearScript\Properties\AssemblyInfo.Windows.tt" Link="Properties\AssemblyInfo.Windows.tt">
             <Generator>TextTemplatingFileGenerator</Generator>
             <LastGenOutput>AssemblyInfo.Windows.cs</LastGenOutput>

--- a/NetFramework/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
+++ b/NetFramework/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
@@ -32,10 +32,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="..\..\ClearScriptBenchmarks\Properties\AssemblyInfo.tt" Link="Properties\AssemblyInfo.tt">
             <Generator>TextTemplatingFileGenerator</Generator>
             <LastGenOutput>AssemblyInfo.cs</LastGenOutput>

--- a/NetFramework/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
+++ b/NetFramework/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net471</TargetFramework>
+        <TargetFrameworks>net45;net471</TargetFrameworks>
         <RootNamespace>Microsoft.ClearScript.Test</RootNamespace>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>

--- a/NetFramework/ClearScriptConsole/ClearScriptConsole.csproj
+++ b/NetFramework/ClearScriptConsole/ClearScriptConsole.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFrameworks>net45;net46</TargetFrameworks>
+        <TargetFrameworks>net45;net471</TargetFrameworks>
         <RootNamespace>Microsoft.ClearScript.Test</RootNamespace>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>

--- a/NetFramework/ClearScriptConsole/ClearScriptConsole.csproj
+++ b/NetFramework/ClearScriptConsole/ClearScriptConsole.csproj
@@ -36,10 +36,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <None Include="..\..\ClearScriptConsole\Properties\AssemblyInfo.tt" Link="Properties\AssemblyInfo.tt">
             <Generator>TextTemplatingFileGenerator</Generator>
             <LastGenOutput>AssemblyInfo.cs</LastGenOutput>

--- a/NetFramework/ClearScriptTest/ClearScriptTest.csproj
+++ b/NetFramework/ClearScriptTest/ClearScriptTest.csproj
@@ -242,10 +242,6 @@
     </ItemGroup>
 
     <ItemGroup>
-        <Folder Include="Properties\" />
-    </ItemGroup>
-
-    <ItemGroup>
         <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\ClearScript.V8\ClearScript.V8.csproj" />
         <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />


### PR DESCRIPTION
This PR has two parts:

1. **Remove non-existent folders** These folders don't actually exist on disk. They are added automatically to the tree for linked items, but listing them explicitly in the project when they don't exist on disk causes them to be shown with error overlays in VS 16.9.
1. **Use consistent target frameworks** This works around an issue that can cause VS to needlessly rebuild these two projects.