### PR TITLE
add missing syntax error mapping entry

### DIFF
--- a/ClearScript/Windows/VBScriptEngine.cs
+++ b/ClearScript/Windows/VBScriptEngine.cs
@@ -74,6 +74,7 @@ namespace Microsoft.ClearScript.Windows
             { 1057, "'Default' specification must also specify 'Public'" },
             { 1005, "Expected '('" },
             { 1006, "Expected ')'" },
+            { 1007, "Expected ']'" },                   // missing in the online documentation
             { 1011, "Expected '='" },
             { 1021, "Expected 'Case'" },
             { 1047, "Expected 'Class'" },


### PR DESCRIPTION
The error 1007 is a valid VBScript compilation error as in JScript.

An unterminated bracket identifier causes the error `Expected ']'`.

Example:

```vb
Dim [terminated], [unterminated
```