### PR TITLE
WindowsScriptEngine: SynchronizationContext variant

### DIFF
--- a/ClearScript.NoV8.sln
+++ b/ClearScript.NoV8.sln
@@ -31,6 +31,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.Windows", "NetC
 		{2179ABA8-4D87-4CC7-B056-48F770FB446E} = {2179ABA8-4D87-4CC7-B056-48F770FB446E}
 	EndProjectSection
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.WindowsSyncContext", "NetCore\ClearScript.WindowsSyncContext\ClearScript.WindowsSyncContext.csproj", "{FFF137AE-2607-4A60-8068-6E370D420EC2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,6 +55,10 @@ Global
 		{8D40DCCD-D812-4BF0-9BA2-116A3F127D2A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8D40DCCD-D812-4BF0-9BA2-116A3F127D2A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8D40DCCD-D812-4BF0-9BA2-116A3F127D2A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FFF137AE-2607-4A60-8068-6E370D420EC2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FFF137AE-2607-4A60-8068-6E370D420EC2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FFF137AE-2607-4A60-8068-6E370D420EC2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FFF137AE-2607-4A60-8068-6E370D420EC2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -62,6 +68,7 @@ Global
 		{2179ABA8-4D87-4CC7-B056-48F770FB446E} = {184998F3-5DCC-4463-86CC-469C13A69BA7}
 		{32DD8677-C243-48BF-8E81-01EA1C14C3E6} = {41FDE4BD-8E1F-406B-A959-C3B2AF52C2E0}
 		{8D40DCCD-D812-4BF0-9BA2-116A3F127D2A} = {41FDE4BD-8E1F-406B-A959-C3B2AF52C2E0}
+		{FFF137AE-2607-4A60-8068-6E370D420EC2} = {41FDE4BD-8E1F-406B-A959-C3B2AF52C2E0}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {F006893F-7CAF-443A-8F72-CA3C29A1BABD}

--- a/ClearScript.sln
+++ b/ClearScript.sln
@@ -3,12 +3,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29418.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScriptTest", "NetFramework\ClearScriptTest\ClearScriptTest.csproj", "{EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptTest", "NetFramework\ClearScriptTest\ClearScriptTest.csproj", "{EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D}"
 	ProjectSection(ProjectDependencies) = postProject
 		{28980C99-77E7-4B62-8484-AF06C5745B8C} = {28980C99-77E7-4B62-8484-AF06C5745B8C}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScriptConsole", "NetFramework\ClearScriptConsole\ClearScriptConsole.csproj", "{28980C99-77E7-4B62-8484-AF06C5745B8C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptConsole", "NetFramework\ClearScriptConsole\ClearScriptConsole.csproj", "{28980C99-77E7-4B62-8484-AF06C5745B8C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5488F9BE-286E-459B-8384-E9EDA331BD5B}"
 	ProjectSection(SolutionItems) = preProject
@@ -21,7 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Version.tt = Version.tt
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScriptBenchmarks", "NetFramework\ClearScriptBenchmarks\ClearScriptBenchmarks.csproj", "{7922A2F5-3585-4A60-98FB-1BDB4D5ECD29}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptBenchmarks", "NetFramework\ClearScriptBenchmarks\ClearScriptBenchmarks.csproj", "{7922A2F5-3585-4A60-98FB-1BDB4D5ECD29}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".NET Core", ".NET Core", "{38987D23-2ED7-473A-9DE5-863E338EF18A}"
 EndProject
@@ -52,11 +52,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ClearScriptV8.win-x86", "Cl
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ClearScriptV8.win-x64", "ClearScriptV8\win-x64\ClearScriptV8.win-x64.vcxproj", "{CDCF4EEA-1CA4-412E-8C77-78893A67A577}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScript.Core", "NetFramework\ClearScript.Core\ClearScript.Core.csproj", "{F1022C3F-AFBC-4F23-B4DE-C6C0742AEFF2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.Core", "NetFramework\ClearScript.Core\ClearScript.Core.csproj", "{F1022C3F-AFBC-4F23-B4DE-C6C0742AEFF2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScript.Windows", "NetFramework\ClearScript.Windows\ClearScript.Windows.csproj", "{BC560FF8-AB7A-4DA9-A1FD-99221447D370}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.Windows", "NetFramework\ClearScript.Windows\ClearScript.Windows.csproj", "{BC560FF8-AB7A-4DA9-A1FD-99221447D370}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScript.V8", "NetFramework\ClearScript.V8\ClearScript.V8.csproj", "{59CC81A3-3D97-469A-9C8B-533F920085F1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.V8", "NetFramework\ClearScript.V8\ClearScript.V8.csproj", "{59CC81A3-3D97-469A-9C8B-533F920085F1}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2D63EA35-BA9C-4E77-B5A4-4938DBBFEFA6} = {2D63EA35-BA9C-4E77-B5A4-4938DBBFEFA6}
 		{CDCF4EEA-1CA4-412E-8C77-78893A67A577} = {CDCF4EEA-1CA4-412E-8C77-78893A67A577}
@@ -94,6 +94,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptTest", "Unix\Cle
 		{EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D} = {EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D}
 		{3CD8AB65-BA34-4BB9-862F-D31CE861560F} = {3CD8AB65-BA34-4BB9-862F-D31CE861560F}
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.WindowsSyncContext", "NetCore\ClearScript.WindowsSyncContext\ClearScript.WindowsSyncContext.csproj", "{C39267BC-6424-4F90-9212-5DA32FF748DE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptTest.SyncContext", "NetCore\ClearScriptTest.SyncContext\ClearScriptTest.SyncContext.csproj", "{5C0957BE-8BD9-489F-9ABF-43FA62707722}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -169,6 +173,14 @@ Global
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C39267BC-6424-4F90-9212-5DA32FF748DE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C39267BC-6424-4F90-9212-5DA32FF748DE}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C39267BC-6424-4F90-9212-5DA32FF748DE}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C39267BC-6424-4F90-9212-5DA32FF748DE}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5C0957BE-8BD9-489F-9ABF-43FA62707722}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5C0957BE-8BD9-489F-9ABF-43FA62707722}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5C0957BE-8BD9-489F-9ABF-43FA62707722}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5C0957BE-8BD9-489F-9ABF-43FA62707722}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -191,6 +203,8 @@ Global
 		{FDFA67F7-AEE6-407A-BF94-ACAD3D735CAB} = {48C9730D-CA6C-47ED-B72C-DB9B6EE24D47}
 		{3CD8AB65-BA34-4BB9-862F-D31CE861560F} = {48C9730D-CA6C-47ED-B72C-DB9B6EE24D47}
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D} = {48C9730D-CA6C-47ED-B72C-DB9B6EE24D47}
+		{C39267BC-6424-4F90-9212-5DA32FF748DE} = {38987D23-2ED7-473A-9DE5-863E338EF18A}
+		{5C0957BE-8BD9-489F-9ABF-43FA62707722} = {38987D23-2ED7-473A-9DE5-863E338EF18A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3BAF1393-35E4-45F1-AC56-4A22646B56E5}

--- a/ClearScript/Properties/AssemblyInfo.Core.cs
+++ b/ClearScript/Properties/AssemblyInfo.Core.cs
@@ -14,7 +14,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("(c) Microsoft Corporation")]
 [assembly: InternalsVisibleTo("ClearScript.V8")]
 [assembly: InternalsVisibleTo("ClearScript.Windows")]
+[assembly: InternalsVisibleTo("ClearScript.WindowsSyncContext")]
 [assembly: InternalsVisibleTo("ClearScriptTest")]
+[assembly: InternalsVisibleTo("ClearScriptTest.SyncContext")]
 
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("7.0.0")]

--- a/ClearScript/Properties/AssemblyInfo.Core.tt
+++ b/ClearScript/Properties/AssemblyInfo.Core.tt
@@ -39,7 +39,9 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyCopyright("(c) Microsoft Corporation")]
 [assembly: InternalsVisibleTo("<#= "ClearScript.V8" + publicKeySpec #>")]
 [assembly: InternalsVisibleTo("<#= "ClearScript.Windows" + publicKeySpec #>")]
+[assembly: InternalsVisibleTo("<#= "ClearScript.WindowsSyncContext" + publicKeySpec #>")]
 [assembly: InternalsVisibleTo("<#= "ClearScriptTest" + publicKeySpec #>")]
+[assembly: InternalsVisibleTo("<#= "ClearScriptTest.SyncContext" + publicKeySpec #>")]
 
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("<#= version.ToString(3) #>")]

--- a/ClearScript/Properties/AssemblyInfo.V8.cs
+++ b/ClearScript/Properties/AssemblyInfo.V8.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("ClearScript")]
 [assembly: AssemblyCopyright("(c) Microsoft Corporation")]
 [assembly: InternalsVisibleTo("ClearScriptTest")]
+[assembly: InternalsVisibleTo("ClearScriptTest.SyncContext")]
 
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("7.0.0")]

--- a/ClearScript/Properties/AssemblyInfo.V8.tt
+++ b/ClearScript/Properties/AssemblyInfo.V8.tt
@@ -38,6 +38,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("ClearScript")]
 [assembly: AssemblyCopyright("(c) Microsoft Corporation")]
 [assembly: InternalsVisibleTo("<#= "ClearScriptTest" + publicKeySpec #>")]
+[assembly: InternalsVisibleTo("<#= "ClearScriptTest.SyncContext" + publicKeySpec #>")]
 
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("<#= version.ToString(3) #>")]

--- a/ClearScript/Properties/AssemblyInfo.Windows.cs
+++ b/ClearScript/Properties/AssemblyInfo.Windows.cs
@@ -13,6 +13,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("ClearScript")]
 [assembly: AssemblyCopyright("(c) Microsoft Corporation")]
 [assembly: InternalsVisibleTo("ClearScriptTest")]
+[assembly: InternalsVisibleTo("ClearScriptTest.SyncContext")]
 
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("7.0.0")]

--- a/ClearScript/Properties/AssemblyInfo.Windows.tt
+++ b/ClearScript/Properties/AssemblyInfo.Windows.tt
@@ -38,6 +38,7 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("ClearScript")]
 [assembly: AssemblyCopyright("(c) Microsoft Corporation")]
 [assembly: InternalsVisibleTo("<#= "ClearScriptTest" + publicKeySpec #>")]
+[assembly: InternalsVisibleTo("<#= "ClearScriptTest.SyncContext" + publicKeySpec #>")]
 
 [assembly: ComVisible(false)]
 [assembly: AssemblyVersion("<#= version.ToString(3) #>")]

--- a/ClearScriptTest/BaseInterfaceMemberAccessTest.cs
+++ b/ClearScriptTest/BaseInterfaceMemberAccessTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ClearScript.Test
             engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
             engine.AddHostObject("host", new ExtendedHostFunctions());
             engine.AddHostObject("mscorlib", HostItemFlags.GlobalMembers, new HostTypeCollection("mscorlib"));
-            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection("ClearScriptTest").GetNamespaceNode("Microsoft.ClearScript.Test"));
+            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection(TestAssemblyName()).GetNamespaceNode("Microsoft.ClearScript.Test"));
             engine.AddHostObject("testObject", testObject = new TestObject());
         }
 

--- a/ClearScriptTest/BaseMemberAccessTest.cs
+++ b/ClearScriptTest/BaseMemberAccessTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ClearScript.Test
             engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
             engine.AddHostObject("host", new ExtendedHostFunctions());
             engine.AddHostObject("mscorlib", HostItemFlags.GlobalMembers, new HostTypeCollection("mscorlib"));
-            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection("ClearScriptTest").GetNamespaceNode("Microsoft.ClearScript.Test"));
+            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection(TestAssemblyName()).GetNamespaceNode("Microsoft.ClearScript.Test"));
             engine.AddHostObject("testObject", testObject = new TestObject());
         }
 

--- a/ClearScriptTest/ClearScriptTest.cs
+++ b/ClearScriptTest/ClearScriptTest.cs
@@ -2,7 +2,11 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Reflection;
 using System.Threading;
+#if USESYNCCONTEXT
+using System.Windows.Threading;
+#endif
 using Microsoft.ClearScript.V8;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
@@ -11,6 +15,22 @@ namespace Microsoft.ClearScript.Test
     public class ClearScriptTest
     {
         public TestContext TestContext { get; set; }
+
+#if USESYNCCONTEXT
+        public static DispatcherSynchronizationContext SetupDispatcherSynchronizationContext()
+        {
+            var context = new DispatcherSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(context);
+            return context;
+        }
+
+        public static MessageQueueSynchronizationContext SetupMessageQueueSynchronizationContext()
+        {
+            var context = new MessageQueueSynchronizationContext();
+            SynchronizationContext.SetSynchronizationContext(context);
+            return context;
+        }
+#endif
 
         public void BaseTestCleanup()
         {
@@ -35,6 +55,11 @@ namespace Microsoft.ClearScript.Test
 
             Assert.AreEqual(0UL, statistics.ContextCount, "Not all V8 contexts were destroyed.");
             Assert.AreEqual(0UL, statistics.IsolateCount, "Not all V8 isolates were destroyed.");
+        }
+
+        public static string TestAssemblyName()
+        {
+            return Assembly.GetExecutingAssembly().GetName().Name;
         }
     }
 }

--- a/ClearScriptTest/ExplicitBaseInterfaceMemberAccessTest.cs
+++ b/ClearScriptTest/ExplicitBaseInterfaceMemberAccessTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ClearScript.Test
             engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
             engine.AddHostObject("host", new ExtendedHostFunctions());
             engine.AddHostObject("mscorlib", HostItemFlags.GlobalMembers, new HostTypeCollection("mscorlib"));
-            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection("ClearScriptTest").GetNamespaceNode("Microsoft.ClearScript.Test"));
+            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection(TestAssemblyName()).GetNamespaceNode("Microsoft.ClearScript.Test"));
             engine.AddHostObject("testObject", testInterface = testObject = new TestObject());
             engine.Execute("var testInterface = host.cast(IExplicitBaseTestInterface, testObject)");
         }

--- a/ClearScriptTest/ExplicitInterfaceMemberAccessTest.cs
+++ b/ClearScriptTest/ExplicitInterfaceMemberAccessTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ClearScript.Test
             engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
             engine.AddHostObject("host", new ExtendedHostFunctions());
             engine.AddHostObject("mscorlib", HostItemFlags.GlobalMembers, new HostTypeCollection("mscorlib"));
-            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection("ClearScriptTest").GetNamespaceNode("Microsoft.ClearScript.Test"));
+            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection(TestAssemblyName()).GetNamespaceNode("Microsoft.ClearScript.Test"));
             engine.AddHostObject("testObject", testInterface = testObject = new TestObject());
             engine.Execute("var testInterface = host.cast(IExplicitTestInterface, testObject)");
         }

--- a/ClearScriptTest/InterfaceMemberAccessTest.cs
+++ b/ClearScriptTest/InterfaceMemberAccessTest.cs
@@ -25,7 +25,7 @@ namespace Microsoft.ClearScript.Test
             engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
             engine.AddHostObject("host", new ExtendedHostFunctions());
             engine.AddHostObject("mscorlib", HostItemFlags.GlobalMembers, new HostTypeCollection("mscorlib"));
-            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection("ClearScriptTest").GetNamespaceNode("Microsoft.ClearScript.Test"));
+            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection(TestAssemblyName()).GetNamespaceNode("Microsoft.ClearScript.Test"));
             engine.AddHostObject("testObject", testObject = new TestObject());
         }
 

--- a/ClearScriptTest/JScriptEngineTest.cs
+++ b/ClearScriptTest/JScriptEngineTest.cs
@@ -1946,8 +1946,14 @@ namespace Microsoft.ClearScript.Test
             Assert.AreEqual("halloween", engine.Evaluate("dict.Item.get('baz')"));
         }
 
+#if !USESYNCCONTEXT
+        // MSXML2.XMLHTTP XMLHttpRequest uses the Windows message queue
+        // to notify the application when data becomes available.
+        // So, all variants of this test need to process the Windows message queue.
+        // This is done either using the WPF Dispatcher,
+        // or using the headless MessageQueueSynchronizationContext provided in this project.
         [TestMethod, TestCategory("JScriptEngine")]
-        public void JScriptEngine_AddCOMType_XMLHTTP()
+        public void JScriptEngine_AddCOMType_XMLHTTP_Dispatcher()
         {
             var status = 0;
             string data = null;
@@ -1993,6 +1999,120 @@ namespace Microsoft.ClearScript.Test
             Assert.AreEqual(200, status);
             Assert.AreEqual("Hello, world!", data);
         }
+#else
+        // MSXML2.XMLHTTP XMLHttpRequest uses the Windows message queue
+        // to notify the application when data becomes available.
+        // So, all variants of this test need to process the Windows message queue.
+        // This is done either using the WPF Dispatcher,
+        // or using the headless MessageQueueSynchronizationContext provided in this project.
+        [TestMethod, TestCategory("JScriptEngine")]
+        public void JScriptEngine_AddCOMType_XMLHTTP_DispatcherSyncContext()
+        {
+            var status = 0;
+            string data = null;
+
+            var thread = new Thread(() =>
+            {
+                var context = SetupDispatcherSynchronizationContext();
+
+                using (var testEngine = new JScriptEngine(WindowsScriptEngineFlags.EnableDebugging | WindowsScriptEngineFlags.EnableStandardsMode))
+                {
+                    testEngine.Script.onComplete = new Action<int, string>((xhrStatus, xhrData) =>
+                    {
+                        status = xhrStatus;
+                        data = xhrData;
+                        Dispatcher.ExitAllFrames();
+                    });
+
+                    context.Post(
+                        (state) =>
+                        {
+                            // ReSharper disable AccessToDisposedClosure
+
+                            testEngine.AddCOMType("XMLHttpRequest", "MSXML2.XMLHTTP");
+                            testEngine.Execute(@"
+                                xhr = new XMLHttpRequest();
+                                xhr.open('POST', 'http://httpbin.org/post', true);
+                                xhr.onreadystatechange = function () {
+                                    if (xhr.readyState == 4) {
+                                        onComplete(xhr.status, JSON.parse(xhr.responseText).data);
+                                    }
+                                };
+                                xhr.send('Hello, world!');
+                            ");
+
+                            // ReSharper restore AccessToDisposedClosure
+                        },
+                        null);
+
+                    Dispatcher.Run();
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            Assert.AreEqual(200, status);
+            Assert.AreEqual("Hello, world!", data);
+        }
+
+        // MSXML2.XMLHTTP XMLHttpRequest uses the Windows message queue
+        // to notify the application when data becomes available.
+        // So, all variants of this test need to process the Windows message queue.
+        // This is done either using the WPF Dispatcher,
+        // or using the headless MessageQueueSynchronizationContext provided in this project.
+        [TestMethod, TestCategory("JScriptEngine")]
+        public void JScriptEngine_AddCOMType_XMLHTTP_MessageQueueSyncContext()
+        {
+            var status = 0;
+            string data = null;
+
+            var thread = new Thread(() =>
+            {
+                using (var context = SetupMessageQueueSynchronizationContext())
+                using (var testEngine = new JScriptEngine(WindowsScriptEngineFlags.EnableDebugging | WindowsScriptEngineFlags.EnableStandardsMode))
+                {
+                    testEngine.Script.onComplete = new Action<int, string>((xhrStatus, xhrData) =>
+                    {
+                        status = xhrStatus;
+                        data = xhrData;
+                        context.Stop();
+                    });
+
+                    context.Post(
+                        (state) =>
+                        {
+                            // ReSharper disable AccessToDisposedClosure
+
+                            testEngine.AddCOMType("XMLHttpRequest", "MSXML2.XMLHTTP");
+                            testEngine.Execute(@"
+                                    xhr = new XMLHttpRequest();
+                                    xhr.open('POST', 'http://httpbin.org/post', true);
+                                    xhr.onreadystatechange = function () {
+                                        if (xhr.readyState == 4) {
+                                            onComplete(xhr.status, JSON.parse(xhr.responseText).data);
+                                        }
+                                    };
+                                    xhr.send('Hello, world!');
+                                ");
+
+                            // ReSharper restore AccessToDisposedClosure
+                        },
+                        null);
+
+                    context.Run();
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+            thread.Join();
+
+            Assert.AreEqual(200, status);
+            Assert.AreEqual("Hello, world!", data);
+        }
+#endif
 
         [TestMethod, TestCategory("JScriptEngine")]
         public void JScriptEngine_EnableAutoHostVariables()
@@ -2665,7 +2785,7 @@ namespace Microsoft.ClearScript.Test
 
         #region miscellaneous
 
-        private const string generalScript =
+        private static readonly string generalScript =
         @"
             System = clr.System;
 
@@ -2715,7 +2835,7 @@ namespace Microsoft.ClearScript.Test
             tlist.Item(1).Name = 'Ellis';
             tlist.Item(0).Name = 'Eóin';
             tlist.Item(1).Name = 'Shane';
-        ";
+        ".Replace("'ClearScriptTest'", $"'{TestAssemblyName()}'");
 
         private const string generalScriptOutput =
         @"

--- a/ClearScriptTest/JavaScript/GeneralSyncContext.js
+++ b/ClearScriptTest/JavaScript/GeneralSyncContext.js
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+System = clr.System;
+
+TestObject = host.type('Microsoft.ClearScript.Test.GeneralTestObject', 'ClearScriptTest.SyncContext');
+tlist = host.newObj(System.Collections.Generic.List(TestObject));
+tlist.Add(host.newObj(TestObject, 'Eóin', 20));
+tlist.Add(host.newObj(TestObject, 'Shane', 16));
+tlist.Add(host.newObj(TestObject, 'Cillian', 8));
+tlist.Add(host.newObj(TestObject, 'Sasha', 6));
+tlist.Add(host.newObj(TestObject, 'Brian', 3));
+
+olist = host.newObj(System.Collections.Generic.List(System.Object));
+olist.Add({ name: 'Brian', age: 3 });
+olist.Add({ name: 'Sasha', age: 6 });
+olist.Add({ name: 'Cillian', age: 8 });
+olist.Add({ name: 'Shane', age: 16 });
+olist.Add({ name: 'Eóin', age: 20 });
+
+dict = host.newObj(System.Collections.Generic.Dictionary(System.String, System.String));
+dict.Add('foo', 'bar');
+dict.Add('baz', 'qux');
+value = host.newVar(System.String);
+result = dict.TryGetValue('foo', value.out);
+
+bag = host.newObj();
+bag.method = function (x) { System.Console.WriteLine(x * x); };
+bag.proc = host.del(System.Action(System.Object), bag.method);
+
+expando = host.newObj(System.Dynamic.ExpandoObject);
+expandoCollection = host.cast(System.Collections.Generic.ICollection(System.Collections.Generic.KeyValuePair(System.String, System.Object)), expando);
+
+function onChange(s, e) {
+    System.Console.WriteLine('Property changed: {0}; new value: {1}', e.PropertyName, s[e.PropertyName]);
+};
+function onStaticChange(s, e) {
+    System.Console.WriteLine('Property changed: {0}; new value: {1} (static event)', e.PropertyName, e.PropertyValue);
+};
+eventCookie = tlist.Item(0).Change.connect(onChange);
+staticEventCookie = TestObject.StaticChange.connect(onStaticChange);
+tlist.Item(0).Name = 'Jerry';
+tlist.Item(1).Name = 'Ellis';
+tlist.Item(0).Name = 'Eóin';
+tlist.Item(1).Name = 'Shane';
+eventCookie.disconnect();
+staticEventCookie.disconnect();
+tlist.Item(0).Name = 'Jerry';
+tlist.Item(1).Name = 'Ellis';
+tlist.Item(0).Name = 'Eóin';
+tlist.Item(1).Name = 'Shane';
+
+Math.round(Math.sin(Math.PI) * 1000e16);

--- a/ClearScriptTest/MemberAccessTest.cs
+++ b/ClearScriptTest/MemberAccessTest.cs
@@ -26,7 +26,7 @@ namespace Microsoft.ClearScript.Test
             engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
             engine.AddHostObject("host", new ExtendedHostFunctions());
             engine.AddHostObject("mscorlib", HostItemFlags.GlobalMembers, new HostTypeCollection("mscorlib"));
-            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection("ClearScriptTest").GetNamespaceNode("Microsoft.ClearScript.Test"));
+            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection(TestAssemblyName()).GetNamespaceNode("Microsoft.ClearScript.Test"));
             engine.AddHostObject("testObject", testObject = new TestObject());
         }
 

--- a/ClearScriptTest/MessageQueueSynchronizationContext.Windows.cs
+++ b/ClearScriptTest/MessageQueueSynchronizationContext.Windows.cs
@@ -1,0 +1,383 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.ComponentModel;
+using System.Runtime.InteropServices;
+using System.Threading;
+
+namespace Microsoft.ClearScript.Test
+{
+    /// <summary>
+    /// An implementation of <see cref="SynchronizationContext"/> that dispatches
+    /// the callbacks on a Windows message queue. It maintains thread affinity,
+    /// and is suitable for use with COM objects like MSXML2.XMLHTTP XMLHttpRequest
+    /// that implements async by posting to the message queue.
+    /// </summary>
+    public class MessageQueueSynchronizationContext : SynchronizationContext, IDisposable
+    {
+        private const uint WM_USER = 0x0400;
+        private const uint WM_STOP = WM_USER + 0;
+        private const uint WM_MESSAGE = WM_USER + 1;
+
+        private readonly ConcurrentQueue<Message> messages = new ConcurrentQueue<Message>();
+        private readonly InvisibleWindow invisibleWindow = new InvisibleWindow();
+        private readonly AutoResetEvent runEvent = new AutoResetEvent(true);
+        private bool disposed;
+
+        public override SynchronizationContext CreateCopy() => this;
+
+        public override void Post(SendOrPostCallback d, object state)
+        {
+            if (d == null)
+            {
+                throw new ArgumentNullException(nameof(d));
+            }
+
+            messages.Enqueue(new Message(d, state));
+            PostMessage(WM_MESSAGE, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        public override void Send(SendOrPostCallback d, object state)
+        {
+            if (d == null)
+            {
+                throw new ArgumentNullException(nameof(d));
+            }
+
+            var ev = new ManualResetEventSlim(false);
+            var message = new Message(d, state, ev);
+
+            try
+            {
+                messages.Enqueue(message);
+                PostMessage(WM_MESSAGE, IntPtr.Zero, IntPtr.Zero);
+                ev.Wait();
+            }
+            finally
+            {
+                ev.Dispose();
+            }
+
+            if (message.Exception != null)
+            {
+                throw new InvalidOperationException("An error occured during the callback invocation", message.Exception);
+            }
+        }
+
+        public void Run()
+        {
+            runEvent.Reset();
+
+            int ret;
+
+            // retrieve messages for any window that belongs to the current thread,
+            // and any messages on the current thread's message queue whose hwnd value is NULL
+            while ((ret = NativeMethods.GetMessage(out NativeMethods.MSG msg, IntPtr.Zero, 0, 0)) != 0)
+            {
+                if (ret == -1)
+                {
+                    // an error occurred
+                    continue;
+                }
+
+                switch (msg.message)
+                {
+                    case WM_STOP:
+                        NativeMethods.PostQuitMessage(0);
+                        break;
+                    case WM_MESSAGE:
+                        ProcessMessage();
+                        break;
+                    default:
+                        NativeMethods.TranslateMessage(ref msg);
+                        NativeMethods.DispatchMessage(ref msg);
+                        break;
+                }
+            }
+
+            runEvent.Set();
+        }
+
+        private void ProcessMessage()
+        {
+            if (!messages.TryDequeue(out var message))
+            {
+                throw new InvalidOperationException("Failed to dequeue message");
+            }
+
+            var previousContext = Current;
+            SetSynchronizationContext(this);
+            try
+            {
+                message.Run();
+            }
+            finally
+            {
+                SetSynchronizationContext(previousContext);
+            }
+        }
+
+        public void Stop()
+        {
+            // tell the message pump to stop
+            PostMessage(WM_STOP, IntPtr.Zero, IntPtr.Zero);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposed)
+            {
+                if (disposing)
+                {
+
+                    Stop();
+
+                    // wait for the pump to stop
+                    runEvent.WaitOne();
+
+                    invisibleWindow.Dispose();
+                }
+
+                disposed = true;
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(disposing: true);
+            GC.SuppressFinalize(this);
+        }
+
+        private void PostMessage(uint msg, IntPtr wParam, IntPtr lParam)
+        {
+            if (!NativeMethods.PostMessage(invisibleWindow.Hwnd, msg, wParam, lParam))
+            {
+                throw new Win32Exception(Marshal.GetLastWin32Error(), "Failed to post message");
+            }
+        }
+
+        private class Message
+        {
+            private readonly SendOrPostCallback Callback;
+            private readonly object State;
+            private readonly ManualResetEventSlim FinishedEvent;
+
+            public Message(
+                SendOrPostCallback callback,
+                object state,
+                ManualResetEventSlim finishedEvent)
+            {
+                Callback = callback;
+                State = state;
+                FinishedEvent = finishedEvent;
+            }
+
+            public Message(SendOrPostCallback callback, object state)
+                : this(callback, state, null)
+            {
+            }
+
+            public Exception Exception { get; private set; }
+
+            public void Run()
+            {
+                try
+                {
+                    Callback(State);
+                }
+#pragma warning disable CA1031 // Do not catch general exception types
+                catch (Exception exception)
+                {
+                    Exception = exception;
+                }
+#pragma warning restore CA1031 // Do not catch general exception types
+                finally
+                {
+                    FinishedEvent?.Set();
+                }
+            }
+        }
+
+        private static class NativeMethods
+        {
+            [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]
+            public struct WNDCLASS
+            {
+                public uint style;
+                public IntPtr lpfnWndProc;
+                public int cbClsExtra;
+                public int cbWndExtra;
+                public IntPtr hInstance;
+                public IntPtr hIcon;
+                public IntPtr hCursor;
+                public IntPtr hbrBackground;
+                [MarshalAs(UnmanagedType.LPWStr)]
+                public string lpszMenuName;
+                [MarshalAs(UnmanagedType.LPWStr)]
+                public string lpszClassName;
+            }
+
+            [StructLayout(LayoutKind.Sequential)]
+            public struct MSG
+            {
+                public IntPtr hwnd;
+                public uint message;
+                public IntPtr wParam;
+                public IntPtr lParam;
+                public uint time;
+            }
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern UInt16 RegisterClassW([In] ref WNDCLASS lpWndClass);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern IntPtr CreateWindowExW(
+               uint dwExStyle,
+               [MarshalAs(UnmanagedType.LPWStr)] string lpClassName,
+               [MarshalAs(UnmanagedType.LPWStr)] string lpWindowName,
+               uint dwStyle,
+               int x,
+               int y,
+               int nWidth,
+               int nHeight,
+               IntPtr hWndParent,
+               IntPtr hMenu,
+               IntPtr hInstance,
+               IntPtr lpParam
+            );
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern IntPtr DefWindowProcW(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+            [DllImport("user32.dll", SetLastError = true)]
+            public static extern bool DestroyWindow(IntPtr hWnd);
+
+            [DllImport("user32.dll")]
+            public static extern bool ShowWindow(IntPtr hWnd, int nCmdShow);
+
+            [DllImport("user32.dll")]
+            public static extern bool UpdateWindow(IntPtr hWnd);
+
+            [return: MarshalAs(UnmanagedType.Bool)]
+            [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+            public static extern bool PostMessage(IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
+
+            [DllImport("user32.dll")]
+            public static extern int GetMessage(out MSG lpMsg, IntPtr hWnd, uint wMsgFilterMin, uint wMsgFilterMax);
+
+            [DllImport("user32.dll")]
+            public static extern bool TranslateMessage([In] ref MSG lpMsg);
+
+            [DllImport("user32.dll")]
+            public static extern IntPtr DispatchMessage([In] ref MSG lpmsg);
+
+            [DllImport("user32.dll")]
+            public static extern void PostQuitMessage(int nExitCode);
+        }
+
+        private sealed class InvisibleWindow : IDisposable
+        {
+            delegate IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
+            private const int ERROR_CLASS_ALREADY_EXISTS = 1410;
+            private const string className = "InvisibleWindow";
+
+            private static readonly WndProc wndProcDelegate;
+
+            private bool disposed;
+
+            static InvisibleWindow()
+            {
+                wndProcDelegate = CustomWndProc;
+
+                var windClass = new NativeMethods.WNDCLASS
+                {
+                    lpszClassName = className,
+                    lpfnWndProc = Marshal.GetFunctionPointerForDelegate(wndProcDelegate)
+                };
+
+                ushort classAtom = NativeMethods.RegisterClassW(ref windClass);
+
+                int lastError = Marshal.GetLastWin32Error();
+
+                if (classAtom == 0 && lastError != ERROR_CLASS_ALREADY_EXISTS)
+                {
+                    throw new Win32Exception(lastError, "Could not register window class");
+                }
+            }
+
+            public InvisibleWindow()
+            {
+                var windClass = new NativeMethods.WNDCLASS
+                {
+                    lpszClassName = className,
+                    lpfnWndProc = Marshal.GetFunctionPointerForDelegate(wndProcDelegate)
+                };
+
+                ushort classAtom = NativeMethods.RegisterClassW(ref windClass);
+
+                int lastError = Marshal.GetLastWin32Error();
+
+                if (classAtom == 0 && lastError != ERROR_CLASS_ALREADY_EXISTS)
+                {
+                    throw new Win32Exception(lastError, "Could not register window class");
+                }
+
+                IntPtr HWND_MESSAGE = new IntPtr(-3);
+
+                Hwnd = NativeMethods.CreateWindowExW(
+                    0,
+                    className,
+                    className,
+                    0, 0, 0, 0, 0,
+                    HWND_MESSAGE, // message-only window
+                    IntPtr.Zero,
+                    IntPtr.Zero,
+                    IntPtr.Zero
+                );
+
+                lastError = Marshal.GetLastWin32Error();
+                if (lastError != 0)
+                {
+                    throw new Win32Exception(lastError, "Could not create the window");
+                }
+
+                const int ShowWindowCommandsNormal = 1;
+                NativeMethods.ShowWindow(Hwnd, ShowWindowCommandsNormal);
+                NativeMethods.UpdateWindow(Hwnd);
+            }
+
+            public IntPtr Hwnd { get; private set; }
+
+            public void Dispose()
+            {
+                Dispose(true);
+                GC.SuppressFinalize(this);
+            }
+
+            private void Dispose(bool disposing)
+            {
+                if (!disposed)
+                {
+                    disposed = true;
+
+                    if (disposing)
+                    {
+                        // Dispose managed resources
+                    }
+
+                    // Dispose unmanaged resources
+                    if (Hwnd != IntPtr.Zero)
+                    {
+                        //NativeMethods.DestroyWindow(Hwnd);
+                        Hwnd = IntPtr.Zero;
+                    }
+                }
+            }
+
+            private static IntPtr CustomWndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+            {
+                return NativeMethods.DefWindowProcW(hWnd, msg, wParam, lParam);
+            }
+        }
+    }
+}

--- a/ClearScriptTest/StaticMemberAccessTest.cs
+++ b/ClearScriptTest/StaticMemberAccessTest.cs
@@ -24,7 +24,7 @@ namespace Microsoft.ClearScript.Test
             engine = new V8ScriptEngine(V8ScriptEngineFlags.EnableDebugging);
             engine.AddHostObject("host", new ExtendedHostFunctions());
             engine.AddHostObject("mscorlib", HostItemFlags.GlobalMembers, new HostTypeCollection("mscorlib"));
-            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection("ClearScriptTest").GetNamespaceNode("Microsoft.ClearScript.Test"));
+            engine.AddHostObject("ClearScriptTest", HostItemFlags.GlobalMembers, new HostTypeCollection(TestAssemblyName()).GetNamespaceNode("Microsoft.ClearScript.Test"));
         }
 
         [TestCleanup]

--- a/ClearScriptTest/V8ScriptEngineTest.cs
+++ b/ClearScriptTest/V8ScriptEngineTest.cs
@@ -3152,7 +3152,7 @@ namespace Microsoft.ClearScript.Test
 
         #region miscellaneous
 
-        private const string generalScript =
+        private static readonly string generalScript =
         @"
             System = clr.System;
 
@@ -3202,7 +3202,7 @@ namespace Microsoft.ClearScript.Test
             tlist.Item(1).Name = 'Ellis';
             tlist.Item(0).Name = 'Eóin';
             tlist.Item(1).Name = 'Shane';
-        ";
+        ".Replace("'ClearScriptTest'", $"'{TestAssemblyName()}'");
 
         private const string generalScriptOutput =
         @"

--- a/ClearScriptTest/VBScript/GeneralSyncContext.vbs
+++ b/ClearScriptTest/VBScript/GeneralSyncContext.vbs
@@ -1,0 +1,65 @@
+﻿' Copyright (c) Microsoft Corporation. All rights reserved.
+' Licensed under the MIT license.
+
+set System = clr.System
+
+set TestObjectT = host.type("Microsoft.ClearScript.Test.GeneralTestObject", "ClearScriptTest.SyncContext")
+set tlist = host.newObj(System.Collections.Generic.List(TestObjectT))
+call tlist.Add(host.newObj(TestObjectT, "Eóin", 20))
+call tlist.Add(host.newObj(TestObjectT, "Shane", 16))
+call tlist.Add(host.newObj(TestObjectT, "Cillian", 8))
+call tlist.Add(host.newObj(TestObjectT, "Sasha", 6))
+call tlist.Add(host.newObj(TestObjectT, "Brian", 3))
+
+class VBTestObject
+   public name
+   public age
+end class
+
+function createTestObject(name, age)
+   dim testObject
+   set testObject = new VBTestObject
+   testObject.name = name
+   testObject.age = age
+   set createTestObject = testObject
+end function
+
+set olist = host.newObj(System.Collections.Generic.List(System.Object))
+call olist.Add(createTestObject("Brian", 3))
+call olist.Add(createTestObject("Sasha", 6))
+call olist.Add(createTestObject("Cillian", 8))
+call olist.Add(createTestObject("Shane", 16))
+call olist.Add(createTestObject("Eóin", 20))
+
+set dict = host.newObj(System.Collections.Generic.Dictionary(System.String, System.String))
+call dict.Add("foo", "bar")
+call dict.Add("baz", "qux")
+set value = host.newVar(System.String)
+result = dict.TryGetValue("foo", value.out)
+
+set expando = host.newObj(System.Dynamic.ExpandoObject)
+set expandoCollection = host.cast(System.Collections.Generic.ICollection(System.Collections.Generic.KeyValuePair(System.String, System.Object)), expando)
+
+set onEventRef = GetRef("onEvent")
+sub onEvent(s, e)
+    call System.Console.WriteLine("Property changed: {0}; new value: {1}", e.PropertyName, eval("s." + e.PropertyName))
+end sub
+
+set onStaticEventRef = GetRef("onStaticEvent")
+sub onStaticEvent(s, e)
+    call System.Console.WriteLine("Property changed: {0}; new value: {1} (static event)", e.PropertyName, e.PropertyValue)
+end sub
+
+set eventCookie = tlist.Item(0).Change.connect(onEventRef)
+set staticEventCookie = TestObjectT.StaticChange.connect(onStaticEventRef)
+tlist.Item(0).Name = "Jerry"
+tlist.Item(1).Name = "Ellis"
+tlist.Item(0).Name = "Eóin"
+tlist.Item(1).Name = "Shane"
+
+call eventCookie.disconnect()
+call staticEventCookie.disconnect()
+tlist.Item(0).Name = "Jerry"
+tlist.Item(1).Name = "Ellis"
+tlist.Item(0).Name = "Eóin"
+tlist.Item(1).Name = "Shane"

--- a/NetCore/ClearScript.WindowsSyncContext/ClearScript.WindowsSyncContext.csproj
+++ b/NetCore/ClearScript.WindowsSyncContext/ClearScript.WindowsSyncContext.csproj
@@ -1,0 +1,58 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
+        <RootNamespace>Microsoft.ClearScript</RootNamespace>
+        <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+        <DefineConstants>USESYNCCONTEXT;TRACE;DEBUG</DefineConstants>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <NoWarn>CS0618;CA1416</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <OutputPath>..\..\bin\Debug</OutputPath>
+        <DocumentationFile>..\..\bin\Debug\$(TargetFramework)\ClearScript.Windows.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+        <DefineConstants>USESYNCCONTEXT;TRACE</DefineConstants>
+        <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+        <NoWarn>CS0618;CA1416</NoWarn>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <OutputPath>..\..\bin\Release</OutputPath>
+        <DocumentationFile>..\..\bin\Release\$(TargetFramework)\ClearScript.Windows.xml</DocumentationFile>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="Exists('$(SolutionDir)ClearScript.snk')">
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>$(SolutionDir)ClearScript.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
+    <PropertyGroup Condition="!Exists('$(SolutionDir)ClearScript.snk') And Exists('$(SolutionDir)ClearScript.DelaySign.snk')">
+        <SignAssembly>true</SignAssembly>
+        <AssemblyOriginatorKeyFile>$(SolutionDir)ClearScript.DelaySign.snk</AssemblyOriginatorKeyFile>
+        <DelaySign>true</DelaySign>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <Compile Include="..\..\ClearScript\Properties\AssemblyInfo.Windows.cs" Link="Properties\AssemblyInfo.Windows.cs" />
+        <Compile Include="..\..\ClearScript\Windows\ActiveXDebugging.cs" Link="Windows\ActiveXDebugging.cs" />
+        <Compile Include="..\..\ClearScript\Windows\ActiveXScripting.cs" Link="Windows\ActiveXScripting.cs" />
+        <Compile Include="..\..\ClearScript\Windows\ActiveXWrappers.cs" Link="Windows\ActiveXWrappers.cs" />
+        <Compile Include="..\..\ClearScript\Windows\IHostWindow.cs" Link="Windows\IHostWindow.cs" />
+        <Compile Include="..\..\ClearScript\Windows\IWindowsScriptObject.cs" Link="Windows\IWindowsScriptObject.cs" />
+        <Compile Include="..\..\ClearScript\Windows\JScriptEngine.cs" Link="Windows\JScriptEngine.cs" />
+        <Compile Include="..\..\ClearScript\Windows\Nothing.cs" Link="Windows\Nothing.cs" />
+        <Compile Include="..\..\ClearScript\Windows\VBScriptEngine.cs" Link="Windows\VBScriptEngine.cs" />
+        <Compile Include="..\..\ClearScript\Windows\WindowsScriptEngine.cs" Link="Windows\WindowsScriptEngine.cs" />
+        <Compile Include="..\..\ClearScript\Windows\WindowsScriptEngine.Debug.cs" Link="Windows\WindowsScriptEngine.Debug.cs" />
+        <Compile Include="..\..\ClearScript\Windows\WindowsScriptEngine.Site.cs" Link="Windows\WindowsScriptEngine.Site.cs" />
+        <Compile Include="..\..\ClearScript\Windows\WindowsScriptEngineFlags.cs" Link="Windows\WindowsScriptEngineFlags.cs" />
+        <Compile Include="..\..\ClearScript\Windows\WindowsScriptItem.cs" Link="Windows\WindowsScriptItem.cs" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/NetCore/ClearScriptTest.SyncContext/ClearScriptTest.SyncContext.csproj
+++ b/NetCore/ClearScriptTest.SyncContext/ClearScriptTest.SyncContext.csproj
@@ -1,20 +1,22 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
 
     <PropertyGroup>
-        <TargetFramework>net471</TargetFramework>
+        <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
         <UseWPF>true</UseWPF>
         <RootNamespace>Microsoft.ClearScript.Test</RootNamespace>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-        <DefineConstants>DEBUG;TRACE</DefineConstants>
+        <DefineConstants>USESYNCCONTEXT;DEBUG;TRACE</DefineConstants>
+        <NoWarn>CA1416</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <OutputPath>..\..\bin\Debug</OutputPath>
     </PropertyGroup>
 
     <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
-        <DefineConstants>TRACE</DefineConstants>
+        <DefineConstants>USESYNCCONTEXT;TRACE</DefineConstants>
+        <NoWarn>CA1416</NoWarn>
         <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
         <OutputPath>..\..\bin\Release</OutputPath>
     </PropertyGroup>
@@ -31,13 +33,12 @@
 
     <ItemGroup>
         <Compile Include="..\..\ClearScriptTest\AccessContextTest.cs" Link="AccessContextTest.cs" />
-        <Compile Include="..\..\ClearScriptTest\BadV8DeploymentTest.cs" Link="BadV8DeploymentTest.cs" />
         <Compile Include="..\..\ClearScriptTest\BaseInterfaceMemberAccessTest.cs" Link="BaseInterfaceMemberAccessTest.cs" />
         <Compile Include="..\..\ClearScriptTest\BaseMemberAccessTest.cs" Link="BaseMemberAccessTest.cs" />
         <Compile Include="..\..\ClearScriptTest\BaseTestObject.cs" Link="BaseTestObject.cs" />
         <Compile Include="..\..\ClearScriptTest\BindSignatureTest.cs" Link="BindSignatureTest.cs" />
         <Compile Include="..\..\ClearScriptTest\BugFixTest.cs" Link="BugFixTest.cs" />
-        <Compile Include="..\..\ClearScriptTest\BugFixTest.NetFramework.cs" Link="BugFixTest.NetFramework.cs" />
+        <Compile Include="..\..\ClearScriptTest\BugFixTest.NetCore.cs" Link="BugFixTest.NetCore.cs" />
         <Compile Include="..\..\ClearScriptTest\BugFixTest.Windows.cs" Link="BugFixTest.Windows.cs" />
         <Compile Include="..\..\ClearScriptTest\ClearScriptTest.cs" Link="ClearScriptTest.cs" />
         <Compile Include="..\..\ClearScriptTest\CrossEngineTest.cs" Link="CrossEngineTest.cs" />
@@ -61,13 +62,10 @@
         <Compile Include="..\..\ClearScriptTest\JScriptEngineTest.cs" Link="JScriptEngineTest.cs" />
         <Compile Include="..\..\ClearScriptTest\JScriptModuleTest.cs" Link="JScriptModuleTest.cs" />
         <Compile Include="..\..\ClearScriptTest\MemberAccessTest.cs" Link="MemberAccessTest.cs" />
+        <Compile Include="..\..\ClearScriptTest\MessageQueueSynchronizationContext.Windows.cs" Link="MessageQueueSynchronizationContext.Windows.cs" />
         <Compile Include="..\..\ClearScriptTest\Misc.cs" Link="Misc.cs" />
-        <Compile Include="..\..\ClearScriptTest\Misc.NetFramework.cs" Link="Misc.NetFramework.cs" />
-        <Compile Include="..\..\ClearScriptTest\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>AssemblyInfo.tt</DependentUpon>
-        </Compile>
+        <Compile Include="..\..\ClearScriptTest\Misc.NetCore.cs" Link="Misc.NetCore.cs" />
+        <Compile Include="..\..\ClearScriptTest\Properties\AssemblyInfo.cs" Link="Properties\AssemblyInfo.cs" />
         <Compile Include="..\..\ClearScriptTest\PropertyBagTest.cs" Link="PropertyBagTest.cs" />
         <Compile Include="..\..\ClearScriptTest\PropertyBagTest.Windows.cs" Link="PropertyBagTest.Windows.cs" />
         <Compile Include="..\..\ClearScriptTest\ScriptAccessTest.cs" Link="ScriptAccessTest.cs" />
@@ -120,7 +118,7 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+        <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="3.7.0" />
     </ItemGroup>
 
     <ItemGroup>
@@ -157,7 +155,7 @@
         <None Include="..\..\ClearScriptTest\JavaScript\CommonJS\NewMath.js" Link="JavaScript\CommonJS\NewMath.js">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="..\..\ClearScriptTest\JavaScript\General.js" Link="JavaScript\General.js">
+        <None Include="..\..\ClearScriptTest\JavaScript\GeneralSyncContext.js" Link="JavaScript\General.js">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
         <None Include="..\..\ClearScriptTest\JavaScript\LegacyCommonJS\Arithmetic\Arithmetic.js" Link="JavaScript\LegacyCommonJS\Arithmetic\Arithmetic.js">
@@ -229,14 +227,10 @@
         <None Include="..\..\ClearScriptTest\JavaScript\StandardModuleWithCycles\ModuleWithSideEffects.js" Link="JavaScript\StandardModuleWithCycles\ModuleWithSideEffects.js">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="..\..\ClearScriptTest\Properties\AssemblyInfo.tt" Link="Properties\AssemblyInfo.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>AssemblyInfo.cs</LastGenOutput>
-        </None>
         <None Include="..\..\ClearScriptTest\VBScript\Expression.vbs" Link="VBScript\Expression.vbs">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
-        <None Include="..\..\ClearScriptTest\VBScript\General.vbs" Link="VBScript\General.vbs">
+        <None Include="..\..\ClearScriptTest\VBScript\GeneralSyncContext.vbs" Link="VBScript\General.vbs">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
     </ItemGroup>
@@ -244,15 +238,7 @@
     <ItemGroup>
         <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\ClearScript.V8\ClearScript.V8.csproj" />
-        <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Reference Include="Microsoft.CSharp" />
-    </ItemGroup>
-
-    <ItemGroup>
-        <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+        <ProjectReference Include="..\ClearScript.WindowsSyncContext\ClearScript.WindowsSyncContext.csproj" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
`WindowsScriptEngine` uses `System.Windows.Threading.Dispatcher`. On .NET Core or .NET 5, this limits its usage to WindowsDesktop projects that use WPF. In other project types, `System.Windows.Threading.Dispatcher` is not available.

Here we add a variant that uses the current `SynchronizationContext` instead. This allows to use the engine in all kinds of projects.

In WindowsDesktop projects that use WPF, the default `SynchronizationContext` is a `DispatcherSynchronizationContext`, so this will keep the same behaviour as the Dispatcher-based version: it maintains thread-affinity by using the Windows message queue for the current thread.
In WindowsDesktop projects that use WinForms, the default `SynchronizationContext` is a `WindowsFormsSynchronizationContext` with the same behaviour.

In other projects, the requirements guide the choice of a `SynchronizationContext`:
- if thread-affinity is not required, callers can use the default `SynchronizationContext` which is based on the threadpool. When there is no current `SynchronizationContext`, `WindowsScriptEngine` will create an instance of the default `SynchronizationContext`.
- if thread-affinity is required, callers can setup a single-thread `SynchronizationContext`,
- if thread-affinity is required and the Windows message queue needs to be processed (for example to use COM objects like the async `MSXML2.XMLHTTP` `XMLHttpRequest`), callers can setup a `SynchronizationContext` based on the Windows message queue, such as the `MessageQueueSynchronizationContext` implemented in the unit tests.

To avoid changing the existing ClearScript distribution, the `WindowsScriptEngine` variant is implemented in a new `ClearScript.WindowsSyncContext` project. A new test project `ClearScriptTest.SyncContext` is also created, it is a copy of `ClearScriptTest` that uses the `WindowsScriptEngine` variant based on the `SynchronizationContext`.

In this project, `***ScriptEngine_AddCOMType_XMLHTTP` unit tests are implemented in 2 versions:
- one which uses the WPF `DispatcherSynchronizationContext`
- one which uses the `MessageQueueSynchronizationContext` implemented in the unit test project

These new projects target .NET Core and .NET 5 (`ClearScript.WindowsSyncContext` could also target netstandard2.0).

Test plan: all unit test pass