### PR TITLE
WindowsScriptEngine: abstract the Dispatcher, allow usage without the WindowsDesktop runtime

### DIFF
--- a/ClearScript.sln
+++ b/ClearScript.sln
@@ -3,12 +3,12 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29418.71
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScriptTest", "NetFramework\ClearScriptTest\ClearScriptTest.csproj", "{EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptTest", "NetFramework\ClearScriptTest\ClearScriptTest.csproj", "{EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D}"
 	ProjectSection(ProjectDependencies) = postProject
 		{28980C99-77E7-4B62-8484-AF06C5745B8C} = {28980C99-77E7-4B62-8484-AF06C5745B8C}
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScriptConsole", "NetFramework\ClearScriptConsole\ClearScriptConsole.csproj", "{28980C99-77E7-4B62-8484-AF06C5745B8C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptConsole", "NetFramework\ClearScriptConsole\ClearScriptConsole.csproj", "{28980C99-77E7-4B62-8484-AF06C5745B8C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{5488F9BE-286E-459B-8384-E9EDA331BD5B}"
 	ProjectSection(SolutionItems) = preProject
@@ -21,7 +21,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		Version.tt = Version.tt
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScriptBenchmarks", "NetFramework\ClearScriptBenchmarks\ClearScriptBenchmarks.csproj", "{7922A2F5-3585-4A60-98FB-1BDB4D5ECD29}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptBenchmarks", "NetFramework\ClearScriptBenchmarks\ClearScriptBenchmarks.csproj", "{7922A2F5-3585-4A60-98FB-1BDB4D5ECD29}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".NET Core", ".NET Core", "{38987D23-2ED7-473A-9DE5-863E338EF18A}"
 EndProject
@@ -52,11 +52,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ClearScriptV8.win-x86", "Cl
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "ClearScriptV8.win-x64", "ClearScriptV8\win-x64\ClearScriptV8.win-x64.vcxproj", "{CDCF4EEA-1CA4-412E-8C77-78893A67A577}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScript.Core", "NetFramework\ClearScript.Core\ClearScript.Core.csproj", "{F1022C3F-AFBC-4F23-B4DE-C6C0742AEFF2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.Core", "NetFramework\ClearScript.Core\ClearScript.Core.csproj", "{F1022C3F-AFBC-4F23-B4DE-C6C0742AEFF2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScript.Windows", "NetFramework\ClearScript.Windows\ClearScript.Windows.csproj", "{BC560FF8-AB7A-4DA9-A1FD-99221447D370}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.Windows", "NetFramework\ClearScript.Windows\ClearScript.Windows.csproj", "{BC560FF8-AB7A-4DA9-A1FD-99221447D370}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClearScript.V8", "NetFramework\ClearScript.V8\ClearScript.V8.csproj", "{59CC81A3-3D97-469A-9C8B-533F920085F1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.V8", "NetFramework\ClearScript.V8\ClearScript.V8.csproj", "{59CC81A3-3D97-469A-9C8B-533F920085F1}"
 	ProjectSection(ProjectDependencies) = postProject
 		{2D63EA35-BA9C-4E77-B5A4-4938DBBFEFA6} = {2D63EA35-BA9C-4E77-B5A4-4938DBBFEFA6}
 		{CDCF4EEA-1CA4-412E-8C77-78893A67A577} = {CDCF4EEA-1CA4-412E-8C77-78893A67A577}
@@ -94,6 +94,10 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScriptTest", "Unix\Cle
 		{EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D} = {EDC7144E-FDA9-4CC7-B2CD-B5EBFD610A7D}
 		{3CD8AB65-BA34-4BB9-862F-D31CE861560F} = {3CD8AB65-BA34-4BB9-862F-D31CE861560F}
 	EndProjectSection
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.WindowsDesktop", "NetCore\ClearScript.WindowsDesktop\ClearScript.WindowsDesktop.csproj", "{60EA858C-3F7B-4879-990F-CB9248254A7D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ClearScript.WindowsDesktop", "NetFramework\ClearScript.WindowsDesktop\ClearScript.WindowsDesktop.csproj", "{B699635B-C073-4861-B85F-66C42C427887}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -169,6 +173,14 @@ Global
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{60EA858C-3F7B-4879-990F-CB9248254A7D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{60EA858C-3F7B-4879-990F-CB9248254A7D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{60EA858C-3F7B-4879-990F-CB9248254A7D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{60EA858C-3F7B-4879-990F-CB9248254A7D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{B699635B-C073-4861-B85F-66C42C427887}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B699635B-C073-4861-B85F-66C42C427887}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B699635B-C073-4861-B85F-66C42C427887}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B699635B-C073-4861-B85F-66C42C427887}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -191,6 +203,8 @@ Global
 		{FDFA67F7-AEE6-407A-BF94-ACAD3D735CAB} = {48C9730D-CA6C-47ED-B72C-DB9B6EE24D47}
 		{3CD8AB65-BA34-4BB9-862F-D31CE861560F} = {48C9730D-CA6C-47ED-B72C-DB9B6EE24D47}
 		{052E036D-6D60-4FCA-AA8E-4CF56BC2058D} = {48C9730D-CA6C-47ED-B72C-DB9B6EE24D47}
+		{60EA858C-3F7B-4879-990F-CB9248254A7D} = {38987D23-2ED7-473A-9DE5-863E338EF18A}
+		{B699635B-C073-4861-B85F-66C42C427887} = {526BA3EF-4E1D-48C1-9923-2485B63993EE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {3BAF1393-35E4-45F1-AC56-4A22646B56E5}

--- a/ClearScript/Properties/AssemblyInfo.WindowsDesktop.cs
+++ b/ClearScript/Properties/AssemblyInfo.WindowsDesktop.cs
@@ -1,0 +1,20 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+
+
+
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClearScript Windows Desktop Library")]
+[assembly: AssemblyProduct("ClearScript")]
+[assembly: AssemblyCopyright("(c) Microsoft Corporation")]
+[assembly: InternalsVisibleTo("ClearScriptTest")]
+
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("7.0.0")]
+[assembly: AssemblyFileVersion("7.0.0")]
+[assembly: AssemblyInformationalVersion("7.0.0")]

--- a/ClearScript/Properties/AssemblyInfo.WindowsDesktop.tt
+++ b/ClearScript/Properties/AssemblyInfo.WindowsDesktop.tt
@@ -1,0 +1,45 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+<#@ template debug="false" hostspecific="true" language="C#" #>
+<#@ output extension=".cs" #>
+<#@ include file="..\..\Version.tt" #>
+
+<#@ assembly name="EnvDTE" #>
+<#@ import namespace="EnvDTE" #>
+<#@ import namespace="System.IO" #>
+<#@ import namespace="System.Reflection" #>
+
+<#
+var dte = (DTE)((IServiceProvider)Host).GetService(typeof(DTE));
+var solutionPath = Path.GetDirectoryName(dte.Solution.FullName);
+var keyFilePath = Path.Combine(solutionPath, "ClearScript.snk");
+var delaySignKeyFilePath = Path.Combine(solutionPath, "ClearScript.DelaySign.snk");
+var publicKeySpec = string.Empty;
+if (File.Exists(keyFilePath))
+{
+    using (var stream = new FileStream(keyFilePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+    {
+        var keyPair = new StrongNameKeyPair(stream);
+        publicKeySpec = ", PublicKey=" + BitConverter.ToString(keyPair.PublicKey).Replace("-", string.Empty);
+    }
+}
+else if (File.Exists(delaySignKeyFilePath))
+{
+    publicKeySpec = ", PublicKey=" + BitConverter.ToString(File.ReadAllBytes(delaySignKeyFilePath)).Replace("-", string.Empty);
+}
+#>
+
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+[assembly: AssemblyTitle("ClearScript Windows Desktop Library")]
+[assembly: AssemblyProduct("ClearScript")]
+[assembly: AssemblyCopyright("(c) Microsoft Corporation")]
+[assembly: InternalsVisibleTo("<#= "ClearScriptTest" + publicKeySpec #>")]
+
+[assembly: ComVisible(false)]
+[assembly: AssemblyVersion("<#= version.ToString(3) #>")]
+[assembly: AssemblyFileVersion("<#= version.ToString(3) #>")]
+[assembly: AssemblyInformationalVersion("<#= version.ToString(3) + versionSuffix #>")]

--- a/ClearScript/Windows/DefaultSyncInvoker.cs
+++ b/ClearScript/Windows/DefaultSyncInvoker.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Threading;
+
+namespace Microsoft.ClearScript.Windows
+{
+    /// <summary>
+    /// An implementation of <see cref="ISyncInvoker"/> that only supports invoking delegates immediately on the current thread.
+    /// This implementation can run anywhere, but does not support scripts that use events which are sent from another thread.
+    /// </summary>
+    public class DefaultSyncInvoker : ISyncInvoker
+    {
+        private readonly Thread thread;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        public DefaultSyncInvoker()
+        {
+            this.thread = Thread.CurrentThread;
+        }
+
+        /// <inheritdoc/>
+        public bool CheckAccess() => Thread.CurrentThread == this.thread;
+
+        /// <inheritdoc/>
+        public void VerifyAccess()
+        {
+            if (!CheckAccess())
+            {
+                throw new InvalidOperationException("The current thread does not have access to this DefaultSyncInvoker");
+            }
+        }
+
+        /// <inheritdoc/>
+        public void Invoke(Action action)
+        {
+            if (!CheckAccess())
+            {
+                throw new NotImplementedException("DefaultSyncInvoker does not support sending a work item from another thread.");
+            }
+
+            action();
+        }
+
+        /// <inheritdoc/>
+        public T Invoke<T>(Func<T> func)
+        {
+            if (!CheckAccess())
+            {
+                throw new NotImplementedException("DefaultSyncInvoker does not support sending a work item from another thread.");
+            }
+
+            return func();
+        }
+    }
+}

--- a/ClearScript/Windows/DispatcherSyncInvoker.cs
+++ b/ClearScript/Windows/DispatcherSyncInvoker.cs
@@ -1,0 +1,54 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+using System.Windows.Threading;
+
+namespace Microsoft.ClearScript.Windows
+{
+    /// <summary>
+    /// An implementation of <see cref="ISyncInvoker"/> based on a <see cref="Dispatcher"/>.
+    /// It processes work items using the Windows message queue. This allows to use script with event handling.
+    /// This also allows to use COM types that implement event handling using the Windows message queue, such as MSXML2.XMLHTTP XMLHttpRequest.
+    /// </summary>
+    public class DispatcherSyncInvoker : ISyncInvoker
+    {
+        private readonly Dispatcher dispatcher;
+
+        /// <summary>
+        /// Creates an instance of <see cref="DispatcherSyncInvoker"/> based on <see cref="Dispatcher.CurrentDispatcher"/>.
+        /// </summary>
+        /// <returns>An instance of <see cref="DispatcherSyncInvoker"/>.</returns>
+        public static DispatcherSyncInvoker FromCurrent()
+        {
+            return new DispatcherSyncInvoker(Dispatcher.CurrentDispatcher);
+        }
+
+        /// <summary>
+        /// Creates an instance of <see cref="DispatcherSyncInvoker"/> with the specified dispatcher.
+        /// </summary>
+        /// <param name="dispatcher">A dispatcher.</param>
+        public DispatcherSyncInvoker(Dispatcher dispatcher)
+        {
+            this.dispatcher = dispatcher;
+        }
+
+        /// <inheritdoc/>
+        public bool CheckAccess() => dispatcher.CheckAccess();
+
+        /// <inheritdoc/>
+        public void Invoke(Action action)
+        {
+            dispatcher.Invoke(DispatcherPriority.Send, action);
+        }
+
+        /// <inheritdoc/>
+        public T Invoke<T>(Func<T> func)
+        {
+            return (T)dispatcher.Invoke(DispatcherPriority.Send, func);
+        }
+
+        /// <inheritdoc/>
+        public void VerifyAccess() => dispatcher.VerifyAccess();
+    }
+}

--- a/ClearScript/Windows/ISyncInvoker.cs
+++ b/ClearScript/Windows/ISyncInvoker.cs
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT license.
+
+using System;
+
+namespace Microsoft.ClearScript.Windows
+{
+    /// <summary>
+    /// An interface to invoke delegates with thread-affinity.
+    /// </summary>
+    public interface ISyncInvoker
+
+    {
+        /// <summary>
+        /// Determines whether the calling thread is the thread associated with this <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <returns></returns>
+        bool CheckAccess();
+
+        /// <summary>
+        /// Determines whether the calling thread has access to this <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">The calling thread does not have access to this <see cref="ISyncInvoker"/>.</exception>
+        void VerifyAccess();
+
+        /// <summary>
+        /// Executes the specified <see cref="Action"/> synchronously on the thread the <see cref="ISyncInvoker"/> is associated with.
+        /// </summary>
+        /// <param name="action"></param>
+        void Invoke(Action action);
+
+        /// <summary>
+        /// Executes the specified <see cref="Func{T}"/> synchronously on the thread the <see cref="ISyncInvoker"/> is associated with.
+        /// </summary>
+        /// <param name="func"></param>
+        T Invoke<T>(Func<T> func);
+    }
+}

--- a/ClearScript/Windows/JScriptEngine.cs
+++ b/ClearScript/Windows/JScriptEngine.cs
@@ -96,7 +96,16 @@ namespace Microsoft.ClearScript.Windows
         /// Initializes a new JScript engine instance.
         /// </summary>
         public JScriptEngine()
-            : this(null)
+            : this(new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new JScript engine instance with the specified <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public JScriptEngine(ISyncInvoker syncInvoker)
+            : this(null, syncInvoker)
         {
         }
 
@@ -105,7 +114,17 @@ namespace Microsoft.ClearScript.Windows
         /// </summary>
         /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
         public JScriptEngine(string name)
-            : this(name, WindowsScriptEngineFlags.None)
+            : this(name, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new JScript engine instance with the specified name and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public JScriptEngine(string name, ISyncInvoker syncInvoker)
+            : this(name, WindowsScriptEngineFlags.None, syncInvoker)
         {
         }
 
@@ -114,7 +133,17 @@ namespace Microsoft.ClearScript.Windows
         /// </summary>
         /// <param name="flags">A value that selects options for the operation.</param>
         public JScriptEngine(WindowsScriptEngineFlags flags)
-            : this(null, flags)
+            : this(flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new JScript engine instance with the specified options and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public JScriptEngine(WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : this(null, flags, syncInvoker)
         {
         }
 
@@ -124,7 +153,18 @@ namespace Microsoft.ClearScript.Windows
         /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
         /// <param name="flags">A value that selects options for the operation.</param>
         public JScriptEngine(string name, WindowsScriptEngineFlags flags)
-            : this("JScript", name, flags)
+            : this(name, flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new JScript engine instance with the specified name, options, and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public JScriptEngine(string name, WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : this("JScript", name, flags, syncInvoker)
         {
         }
 
@@ -140,7 +180,24 @@ namespace Microsoft.ClearScript.Windows
         /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
         /// </remarks>
         protected JScriptEngine(string progID, string name, WindowsScriptEngineFlags flags)
-            : this(progID, name, "js", flags)
+            : this(progID, name, flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new JScript engine instance with the specified programmatic
+        /// identifier, name, options, and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="progID">The programmatic identifier (ProgID) of the JScript engine class.</param>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        /// <remarks>
+        /// The <paramref name="progID"/> argument can be a class identifier (CLSID) in standard
+        /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
+        /// </remarks>
+        protected JScriptEngine(string progID, string name, WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : this(progID, name, "js", flags, syncInvoker)
         {
         }
 
@@ -157,7 +214,25 @@ namespace Microsoft.ClearScript.Windows
         /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
         /// </remarks>
         protected JScriptEngine(string progID, string name, string fileNameExtensions, WindowsScriptEngineFlags flags)
-            : base(progID, name, fileNameExtensions, flags)
+            : this(progID, name, fileNameExtensions, flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new JScript engine instance with the specified programmatic
+        /// identifier, name, list of supported file name extensions, and options.
+        /// </summary>
+        /// <param name="progID">The programmatic identifier (ProgID) of the JScript engine class.</param>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="fileNameExtensions">A semicolon-delimited list of supported file name extensions.</param>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        /// <remarks>
+        /// The <paramref name="progID"/> argument can be a class identifier (CLSID) in standard
+        /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
+        /// </remarks>
+        protected JScriptEngine(string progID, string name, string fileNameExtensions, WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : base(progID, name, fileNameExtensions, flags, syncInvoker)
         {
             Execute(
                 MiscHelpers.FormatInvariant("{0} [internal]", GetType().Name),

--- a/ClearScript/Windows/VBScriptEngine.cs
+++ b/ClearScript/Windows/VBScriptEngine.cs
@@ -126,7 +126,16 @@ namespace Microsoft.ClearScript.Windows
         /// Initializes a new VBScript engine instance.
         /// </summary>
         public VBScriptEngine()
-            : this(null)
+            : this(new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new VBScript engine instance with the specified <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public VBScriptEngine(ISyncInvoker syncInvoker)
+            : this(null, syncInvoker)
         {
         }
 
@@ -135,7 +144,17 @@ namespace Microsoft.ClearScript.Windows
         /// </summary>
         /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
         public VBScriptEngine(string name)
-            : this(name, WindowsScriptEngineFlags.None)
+            : this(name, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new VBScript engine instance with the specified name and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public VBScriptEngine(string name, ISyncInvoker syncInvoker)
+            : this(name, WindowsScriptEngineFlags.None, syncInvoker)
         {
         }
 
@@ -144,7 +163,17 @@ namespace Microsoft.ClearScript.Windows
         /// </summary>
         /// <param name="flags">A value that selects options for the operation.</param>
         public VBScriptEngine(WindowsScriptEngineFlags flags)
-            : this(null, flags)
+            : this(flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new VBScript engine instance with the specified options and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public VBScriptEngine(WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : this(null, flags, syncInvoker)
         {
         }
 
@@ -154,7 +183,18 @@ namespace Microsoft.ClearScript.Windows
         /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
         /// <param name="flags">A value that selects options for the operation.</param>
         public VBScriptEngine(string name, WindowsScriptEngineFlags flags)
-            : this("VBScript", name, flags)
+            : this(name, flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new VBScript engine instance with the specified name, options, and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        public VBScriptEngine(string name, WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : this("VBScript", name, flags, syncInvoker)
         {
         }
 
@@ -170,7 +210,24 @@ namespace Microsoft.ClearScript.Windows
         /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
         /// </remarks>
         protected VBScriptEngine(string progID, string name, WindowsScriptEngineFlags flags)
-            : this(progID, name, "vbs", flags)
+            : this(progID, name, flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new VBScript engine instance with the specified programmatic
+        /// identifier, name, options, and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="progID">The programmatic identifier (ProgID) of the VBScript engine class.</param>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        /// <remarks>
+        /// The <paramref name="progID"/> argument can be a class identifier (CLSID) in standard
+        /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
+        /// </remarks>
+        protected VBScriptEngine(string progID, string name, WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : this(progID, name, "vbs", flags, syncInvoker)
         {
         }
 
@@ -187,7 +244,25 @@ namespace Microsoft.ClearScript.Windows
         /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
         /// </remarks>
         protected VBScriptEngine(string progID, string name, string fileNameExtensions, WindowsScriptEngineFlags flags)
-            : base(progID, name, fileNameExtensions, flags)
+            : this(progID, name, fileNameExtensions, flags, new DefaultSyncInvoker())
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new VBScript engine instance with the specified programmatic
+        /// identifier, name, list of supported file name extensions, options, and <see cref="ISyncInvoker"/>.
+        /// </summary>
+        /// <param name="progID">The programmatic identifier (ProgID) of the VBScript engine class.</param>
+        /// <param name="name">A name to associate with the instance. Currently this name is used only as a label in presentation contexts such as debugger user interfaces.</param>
+        /// <param name="fileNameExtensions">A semicolon-delimited list of supported file name extensions.</param>
+        /// <param name="flags">A value that selects options for the operation.</param>
+        /// <param name="syncInvoker">A synchronous invoker.</param>
+        /// <remarks>
+        /// The <paramref name="progID"/> argument can be a class identifier (CLSID) in standard
+        /// GUID format with braces (e.g., "{F414C260-6AC0-11CF-B6D1-00AA00BBBB58}").
+        /// </remarks>
+        protected VBScriptEngine(string progID, string name, string fileNameExtensions, WindowsScriptEngineFlags flags, ISyncInvoker syncInvoker)
+            : base(progID, name, fileNameExtensions, flags, syncInvoker)
         {
             Execute(
                 MiscHelpers.FormatInvariant("{0} [internal]", GetType().Name),

--- a/ClearScriptTest/JScriptEngineTest.cs
+++ b/ClearScriptTest/JScriptEngineTest.cs
@@ -1954,7 +1954,9 @@ namespace Microsoft.ClearScript.Test
 
             var thread = new Thread(() =>
             {
-                using (var testEngine = new JScriptEngine(WindowsScriptEngineFlags.EnableDebugging | WindowsScriptEngineFlags.EnableStandardsMode))
+                using (var testEngine = new JScriptEngine(
+                    WindowsScriptEngineFlags.EnableDebugging | WindowsScriptEngineFlags.EnableStandardsMode,
+                    DispatcherSyncInvoker.FromCurrent()))
                 {
                     testEngine.Script.onComplete = new Action<int, string>((xhrStatus, xhrData) =>
                     {

--- a/ClearScriptTest/VBScriptEngineTest.cs
+++ b/ClearScriptTest/VBScriptEngineTest.cs
@@ -2087,9 +2087,9 @@ namespace Microsoft.ClearScript.Test
 
             var thread = new Thread(() =>
             {
-                using (var testEngine = new VBScriptEngine(WindowsScriptEngineFlags.EnableDebugging))
+                using (var testEngine = new VBScriptEngine(WindowsScriptEngineFlags.EnableDebugging, DispatcherSyncInvoker.FromCurrent()))
                 {
-                    using (var helperEngine = new JScriptEngine(WindowsScriptEngineFlags.EnableStandardsMode))
+                    using (var helperEngine = new JScriptEngine(WindowsScriptEngineFlags.EnableStandardsMode, DispatcherSyncInvoker.FromCurrent()))
                     {
                         // ReSharper disable AccessToDisposedClosure
 

--- a/NetCore/ClearScript.Windows/ClearScript.Windows.csproj
+++ b/NetCore/ClearScript.Windows/ClearScript.Windows.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
-        <UseWPF>true</UseWPF>
         <RootNamespace>Microsoft.ClearScript</RootNamespace>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
@@ -40,6 +39,8 @@
         <Compile Include="..\..\ClearScript\Windows\ActiveXDebugging.cs" Link="Windows\ActiveXDebugging.cs" />
         <Compile Include="..\..\ClearScript\Windows\ActiveXScripting.cs" Link="Windows\ActiveXScripting.cs" />
         <Compile Include="..\..\ClearScript\Windows\ActiveXWrappers.cs" Link="Windows\ActiveXWrappers.cs" />
+        <Compile Include="..\..\ClearScript\Windows\DefaultSyncInvoker.cs" Link="Windows\DefaultSyncInvoker.cs" />
+        <Compile Include="..\..\ClearScript\Windows\ISyncInvoker.cs" Link="Windows\ISyncInvoker.cs" />
         <Compile Include="..\..\ClearScript\Windows\IHostWindow.cs" Link="Windows\IHostWindow.cs" />
         <Compile Include="..\..\ClearScript\Windows\IWindowsScriptObject.cs" Link="Windows\IWindowsScriptObject.cs" />
         <Compile Include="..\..\ClearScript\Windows\JScriptEngine.cs" Link="Windows\JScriptEngine.cs" />

--- a/NetCore/ClearScript.WindowsDesktop/ClearScript.WindowsDesktop.csproj
+++ b/NetCore/ClearScript.WindowsDesktop/ClearScript.WindowsDesktop.csproj
@@ -1,0 +1,45 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.1;net5.0-windows</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>Microsoft.ClearScript</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>CS0618;CA1416</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OutputPath>..\..\bin\Debug</OutputPath>
+    <DocumentationFile>..\..\bin\Debug\$(TargetFramework)\ClearScript.WindowsDesktop.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>CS0618;CA1416</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OutputPath>..\..\bin\Release</OutputPath>
+    <DocumentationFile>..\..\bin\Release\$(TargetFramework)\ClearScript.WindowsDesktop.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="Exists('$(SolutionDir)ClearScript.snk')">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)ClearScript.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="!Exists('$(SolutionDir)ClearScript.snk') And Exists('$(SolutionDir)ClearScript.DelaySign.snk')">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)ClearScript.DelaySign.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>true</DelaySign>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\ClearScript\Properties\AssemblyInfo.WindowsDesktop.cs" Link="Properties\AssemblyInfo.WindowsDesktop.cs" />
+    <Compile Include="..\..\ClearScript\Windows\DispatcherSyncInvoker.cs" Link="Windows\DispatcherSyncInvoker.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />
+  </ItemGroup>
+</Project>

--- a/NetCore/ClearScriptTest/ClearScriptTest.csproj
+++ b/NetCore/ClearScriptTest/ClearScriptTest.csproj
@@ -237,6 +237,7 @@
         <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\ClearScript.V8\ClearScript.V8.csproj" />
         <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />
+        <ProjectReference Include="..\ClearScript.WindowsDesktop\ClearScript.WindowsDesktop.csproj" />
     </ItemGroup>
 
 </Project>

--- a/NetFramework/ClearScript.Windows/ClearScript.Windows.csproj
+++ b/NetFramework/ClearScript.Windows/ClearScript.Windows.csproj
@@ -1,8 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
         <TargetFramework>net45</TargetFramework>
-        <UseWPF>true</UseWPF>
         <RootNamespace>Microsoft.ClearScript</RootNamespace>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     </PropertyGroup>
@@ -42,7 +41,9 @@
         <Compile Include="..\..\ClearScript\Windows\ActiveXDebugging.cs" Link="Windows\ActiveXDebugging.cs" />
         <Compile Include="..\..\ClearScript\Windows\ActiveXScripting.cs" Link="Windows\ActiveXScripting.cs" />
         <Compile Include="..\..\ClearScript\Windows\ActiveXWrappers.cs" Link="Windows\ActiveXWrappers.cs" />
+        <Compile Include="..\..\ClearScript\Windows\DefaultSyncInvoker.cs" Link="Windows\DefaultSyncInvoker.cs" />
         <Compile Include="..\..\ClearScript\Windows\IHostWindow.cs" Link="Windows\IHostWindow.cs" />
+        <Compile Include="..\..\ClearScript\Windows\ISyncInvoker.cs" Link="Windows\ISyncInvoker.cs" />
         <Compile Include="..\..\ClearScript\Windows\IWindowsScriptObject.cs" Link="Windows\IWindowsScriptObject.cs" />
         <Compile Include="..\..\ClearScript\Windows\JScriptEngine.cs" Link="Windows\JScriptEngine.cs" />
         <Compile Include="..\..\ClearScript\Windows\Nothing.cs" Link="Windows\Nothing.cs" />

--- a/NetFramework/ClearScript.WindowsDesktop/ClearScript.WindowsDesktop.csproj
+++ b/NetFramework/ClearScript.WindowsDesktop/ClearScript.WindowsDesktop.csproj
@@ -1,0 +1,60 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <UseWPF>true</UseWPF>
+    <RootNamespace>Microsoft.ClearScript</RootNamespace>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <DefineConstants>TRACE;DEBUG</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>CS0618;CA1416</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OutputPath>..\..\bin\Debug</OutputPath>
+    <DocumentationFile>..\..\bin\Debug\$(TargetFramework)\ClearScript.WindowsDesktop.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <DefineConstants>TRACE</DefineConstants>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <NoWarn>CS0618;CA1416</NoWarn>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <OutputPath>..\..\bin\Release</OutputPath>
+    <DocumentationFile>..\..\bin\Release\$(TargetFramework)\ClearScript.WindowsDesktop.xml</DocumentationFile>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="Exists('$(SolutionDir)ClearScript.snk')">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)ClearScript.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <PropertyGroup Condition="!Exists('$(SolutionDir)ClearScript.snk') And Exists('$(SolutionDir)ClearScript.DelaySign.snk')">
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>$(SolutionDir)ClearScript.DelaySign.snk</AssemblyOriginatorKeyFile>
+    <DelaySign>true</DelaySign>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\..\ClearScript\Properties\AssemblyInfo.WindowsDesktop.cs" Link="Properties\AssemblyInfo.WindowsDesktop.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>AssemblyInfo.WindowsDesktop.tt</DependentUpon>
+    </Compile>
+    <Compile Include="..\..\ClearScript\Windows\DispatcherSyncInvoker.cs" Link="Windows\DispatcherSyncInvoker.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\ClearScript\Properties\AssemblyInfo.WindowsDesktop.tt" Link="Properties\AssemblyInfo.WindowsDesktop.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>AssemblyInfo.WindowsDesktop.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+</Project>

--- a/NetFramework/ClearScriptTest/ClearScriptTest.csproj
+++ b/NetFramework/ClearScriptTest/ClearScriptTest.csproj
@@ -245,6 +245,7 @@
         <ProjectReference Include="..\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\ClearScript.V8\ClearScript.V8.csproj" />
         <ProjectReference Include="..\ClearScript.Windows\ClearScript.Windows.csproj" />
+        <ProjectReference Include="..\ClearScript.WindowsDesktop\ClearScript.WindowsDesktop.csproj" />
     </ItemGroup>
 
     <ItemGroup>


### PR DESCRIPTION
`WindowsScriptEngine` uses `System.Windows.Threading.Dispatcher`. On .NET Core or .NET 5, this requires the WindowsDesktop runtime to be installed on the host.

Here we abstract the use of the `Dispatcher` in an `ISyncInvoker` interface, so that `ClearScript.Windows` can be distributed without the dependency on the WindowsDesktop runtime. `ISyncInvoker` is an interface that represents the fact that Windows Script engines require thread-affinity.

Constructor overloads are added to `JScriptEngine` and `VBScriptEngine` to pass an instance of `ISyncInvoker`.

Constructors that take no `ISyncInvoker` parameter create a `DefaultSyncInvoker`, which is a very simple implementation suitable for scripts that do not perform any form of event handling.

A separate `DispatcherSyncInvoker` is provided for the other use cases. It is distributed in a separate `ClearScript.WindowsDesktop` project. It is implemented using a `System.Windows.Threading.Dispatcher`, which is suitable for scripts that use event handling, or scripts that need the Windows message queue to be processed.

Test plan:
- all unit test pass
- `ClearScript.Windows` can be referenced in another project that does not enables `UseWPF`, and can be run on a host where the WindowsDesktop runtime is not installed