### PR TITLE
Android V8 Support

### DIFF
--- a/ClearScript/HostSettings.cs
+++ b/ClearScript/HostSettings.cs
@@ -34,5 +34,14 @@ namespace Microsoft.ClearScript
         /// resources such as native assemblies and related data files.
         /// </remarks>
         public static string AuxiliarySearchPath { get; set; }
+
+        /// <summary>
+        /// Sets the runtime platform to android and loads android native binaries.
+        /// </summary>
+        /// <remarks>
+        /// This property allows ClearScript to load android native assemblies instead of 
+        /// linux assemblies on Android Mono
+        /// </remarks>
+        public static bool IsAndroid { get; set; }
     }
 }

--- a/ClearScript/Util/MiscHelpers.cs
+++ b/ClearScript/Util/MiscHelpers.cs
@@ -543,7 +543,12 @@ namespace Microsoft.ClearScript.Util
 
         public static bool PlatformIsLinux()
         {
-            return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            return !HostSettings.IsAndroid && RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+        }
+
+        public static bool PlatformIsAndroid()
+        {
+            return HostSettings.IsAndroid;
         }
 
         public static bool PlatformIsOSX()

--- a/ClearScript/Util/NativeMethods.cs
+++ b/ClearScript/Util/NativeMethods.cs
@@ -16,6 +16,11 @@ namespace Microsoft.ClearScript.Util
                 return NativeWindowsMethods.LoadLibraryW(path);
             }
 
+            if (MiscHelpers.PlatformIsAndroid())
+            {
+                return NativeAndroidMethods.LoadLibrary(path);
+            }
+
             if (MiscHelpers.PlatformIsLinux())
             {
                 return NativeLinuxMethods.LoadLibrary(path);
@@ -36,6 +41,11 @@ namespace Microsoft.ClearScript.Util
                 return NativeWindowsMethods.FreeLibrary(hLibrary);
             }
 
+            if (MiscHelpers.PlatformIsAndroid())
+            {
+                return NativeAndroidMethods.FreeLibrary(hLibrary) == 0;
+            }
+
             if (MiscHelpers.PlatformIsLinux())
             {
                 return NativeLinuxMethods.FreeLibrary(hLibrary) == 0;
@@ -54,6 +64,11 @@ namespace Microsoft.ClearScript.Util
             if (MiscHelpers.PlatformIsWindows())
             {
                 return new Win32Exception().Message;
+            }
+
+            if (MiscHelpers.PlatformIsAndroid())
+            {
+                return Marshal.PtrToStringAnsi(NativeAndroidMethods.GetLoadLibraryErrorMessage());
             }
 
             if (MiscHelpers.PlatformIsLinux())
@@ -284,7 +299,46 @@ namespace Microsoft.ClearScript.Util
 
             [DllImport("libdl.so", EntryPoint = "dlopen")]
             public static extern IntPtr LoadLibrary(
-                [In] [MarshalAs(UnmanagedType.LPStr)] string path,
+                [In][MarshalAs(UnmanagedType.LPStr)] string path,
+                [In] LoadLibraryFlags flags = LoadLibraryFlags.Now | LoadLibraryFlags.Global
+            );
+
+            [DllImport("libdl.so", EntryPoint = "dlclose")]
+            public static extern int FreeLibrary(
+                [In] IntPtr hLibrary
+            );
+
+            [DllImport("libdl.so", EntryPoint = "dlerror")]
+            public static extern IntPtr GetLoadLibraryErrorMessage();
+
+            // ReSharper restore MemberHidesStaticFromOuterClass
+        }
+
+        #endregion
+
+        #region Nested type: NativeLinuxMethods
+
+        private static class NativeAndroidMethods
+        {
+            // ReSharper disable MemberHidesStaticFromOuterClass
+
+            [Flags]
+            public enum LoadLibraryFlags
+            {
+                // ReSharper disable UnusedMember.Local
+
+                None = 0,
+                Now = 0,
+                Lazy = 1,
+                Local = 0,
+                Global = 2,
+
+                // ReSharper restore UnusedMember.Local
+            }
+
+            [DllImport("libdl.so", EntryPoint = "dlopen")]
+            public static extern IntPtr LoadLibrary(
+                [In][MarshalAs(UnmanagedType.LPStr)] string path,
                 [In] LoadLibraryFlags flags = LoadLibraryFlags.Now | LoadLibraryFlags.Global
             );
 

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.Common.tt
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.Common.tt
@@ -10,21 +10,19 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         private static IV8SplitProxyNative CreateInstance()
         {
-            var architecture = RuntimeInformation.ProcessArchitecture;
-
             <#
             foreach (var osPlatform in platforms.Select(testPlatform => testPlatform.Item1).Distinct())
             {
             #>
 
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.<#= osPlatform #>))
+            if (IsOSPlatform("<#= osPlatform #>"))
             {
                 <#
                 foreach (var platform in platforms.Where(testPlatform => testPlatform.Item1 == osPlatform))
                 {
                 #>
 
-                if (architecture == Architecture.<#= platform.Item2 #>)
+                if (IsArchitecture("<#= osPlatform #>", "<#= platform.Item2 #>"))
                 {
                     return new <#= $"Impl_{osPlatform}_{platform.Item2}" #>();
                 }

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.Generated.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.Generated.cs
@@ -4,6 +4,11 @@
 
 
 
+
+
+
+
+
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT license.
 
@@ -16,82 +21,119 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         private static IV8SplitProxyNative CreateInstance()
         {
-            var architecture = RuntimeInformation.ProcessArchitecture;
-
             
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+
+            if (IsOSPlatform("Windows"))
             {
                 
-                if (architecture == Architecture.X86)
+
+                if (IsArchitecture("Windows", "X86"))
                 {
                     return new Impl_Windows_X86();
                 }
 
                 
-                if (architecture == Architecture.X64)
+
+                if (IsArchitecture("Windows", "X64"))
                 {
                     return new Impl_Windows_X64();
                 }
 
                 
-                if (architecture == Architecture.Arm64)
+
+                if (IsArchitecture("Windows", "Arm64"))
                 {
                     return new Impl_Windows_Arm64();
                 }
 
                 
+
                 throw new PlatformNotSupportedException("Unsupported process architecture");
             }
 
             
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+
+            if (IsOSPlatform("Android"))
             {
                 
-                if (architecture == Architecture.X64)
+
+                if (IsArchitecture("Android", "Arm64"))
+                {
+                    return new Impl_Android_Arm64();
+                }
+
+                
+
+                if (IsArchitecture("Android", "Arm"))
+                {
+                    return new Impl_Android_Arm();
+                }
+
+                
+
+                throw new PlatformNotSupportedException("Unsupported process architecture");
+            }
+
+            
+
+            if (IsOSPlatform("Linux"))
+            {
+                
+
+                if (IsArchitecture("Linux", "X64"))
                 {
                     return new Impl_Linux_X64();
                 }
 
                 
-                if (architecture == Architecture.Arm64)
+
+                if (IsArchitecture("Linux", "Arm64"))
                 {
                     return new Impl_Linux_Arm64();
                 }
 
                 
-                if (architecture == Architecture.Arm)
+
+                if (IsArchitecture("Linux", "Arm"))
                 {
                     return new Impl_Linux_Arm();
                 }
 
                 
+
                 throw new PlatformNotSupportedException("Unsupported process architecture");
             }
 
             
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+
+            if (IsOSPlatform("OSX"))
             {
                 
-                if (architecture == Architecture.X64)
+
+                if (IsArchitecture("OSX", "X64"))
                 {
                     return new Impl_OSX_X64();
                 }
 
                 
-                if (architecture == Architecture.Arm64)
+
+                if (IsArchitecture("OSX", "Arm64"))
                 {
                     return new Impl_OSX_Arm64();
                 }
 
                 
+
                 throw new PlatformNotSupportedException("Unsupported process architecture");
             }
 
             
+
             throw new PlatformNotSupportedException("Unsupported operating system");
         }
 
         
+
         #region Nested type: Impl_Windows_X86
 
         private sealed class Impl_Windows_X86 : IV8SplitProxyNative
@@ -2001,6 +2043,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Windows_X64
 
         private sealed class Impl_Windows_X64 : IV8SplitProxyNative
@@ -3910,6 +3953,3827 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
+        #region Nested type: Impl_Android_Arm64
+
+        private sealed class Impl_Android_Arm64 : IV8SplitProxyNative
+        {
+            public static readonly IV8SplitProxyNative Instance = new Impl_Android_Arm64();
+
+            #region IV8SplitProxyNative implementation
+
+            #region initialization
+
+            IntPtr IV8SplitProxyNative.V8SplitProxyManaged_SetMethodTable(IntPtr pMethodTable)
+            {
+                return V8SplitProxyManaged_SetMethodTable(pMethodTable);
+            }
+
+            void IV8SplitProxyNative.V8Environment_InitializeICU(string dataPath)
+            {
+                V8Environment_InitializeICU(dataPath);
+            }
+
+            #endregion
+
+            #region StdString methods
+
+            StdString.Ptr IV8SplitProxyNative.StdString_New(string value)
+            {
+                return StdString_New(value, value.Length);
+            }
+
+            string IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString)
+            {
+                var pValue = StdString_GetValue(pString, out var length);
+                return Marshal.PtrToStringUni(pValue, length);
+            }
+
+            void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
+            {
+                StdString_SetValue(pString, value, value.Length);
+            }
+
+            void IV8SplitProxyNative.StdString_Delete(StdString.Ptr pString)
+            {
+                StdString_Delete(pString);
+            }
+
+            #endregion
+
+            #region StdStringArray methods
+
+            StdStringArray.Ptr IV8SplitProxyNative.StdStringArray_New(int elementCount)
+            {
+                return StdStringArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdStringArray_GetElementCount(StdStringArray.Ptr pArray)
+            {
+                return StdStringArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdStringArray_SetElementCount(StdStringArray.Ptr pArray, int elementCount)
+            {
+                StdStringArray_SetElementCount(pArray, elementCount);
+            }
+
+            string IV8SplitProxyNative.StdStringArray_GetElement(StdStringArray.Ptr pArray, int index)
+            {
+                var pValue = StdStringArray_GetElement(pArray, index, out var length);
+                return Marshal.PtrToStringUni(pValue, length);
+            }
+
+            void IV8SplitProxyNative.StdStringArray_SetElement(StdStringArray.Ptr pArray, int index, string value)
+            {
+                StdStringArray_SetElement(pArray, index, value, value.Length);
+            }
+
+            void IV8SplitProxyNative.StdStringArray_Delete(StdStringArray.Ptr pArray)
+            {
+                StdStringArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdByteArray methods
+
+            StdByteArray.Ptr IV8SplitProxyNative.StdByteArray_New(int elementCount)
+            {
+                return StdByteArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdByteArray_GetElementCount(StdByteArray.Ptr pArray)
+            {
+                return StdByteArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdByteArray_SetElementCount(StdByteArray.Ptr pArray, int elementCount)
+            {
+                StdByteArray_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdByteArray_GetData(StdByteArray.Ptr pArray)
+            {
+                return StdByteArray_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdByteArray_Delete(StdByteArray.Ptr pArray)
+            {
+                StdByteArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdInt32Array methods
+
+            StdInt32Array.Ptr IV8SplitProxyNative.StdInt32Array_New(int elementCount)
+            {
+                return StdInt32Array_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdInt32Array_GetElementCount(StdInt32Array.Ptr pArray)
+            {
+                return StdInt32Array_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdInt32Array_SetElementCount(StdInt32Array.Ptr pArray, int elementCount)
+            {
+                StdInt32Array_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdInt32Array_GetData(StdInt32Array.Ptr pArray)
+            {
+                return StdInt32Array_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdInt32Array_Delete(StdInt32Array.Ptr pArray)
+            {
+                StdInt32Array_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdUInt32Array methods
+
+            StdUInt32Array.Ptr IV8SplitProxyNative.StdUInt32Array_New(int elementCount)
+            {
+                return StdUInt32Array_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdUInt32Array_GetElementCount(StdUInt32Array.Ptr pArray)
+            {
+                return StdUInt32Array_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt32Array_SetElementCount(StdUInt32Array.Ptr pArray, int elementCount)
+            {
+                StdUInt32Array_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdUInt32Array_GetData(StdUInt32Array.Ptr pArray)
+            {
+                return StdUInt32Array_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt32Array_Delete(StdUInt32Array.Ptr pArray)
+            {
+                StdUInt32Array_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdUInt64Array methods
+
+            StdUInt64Array.Ptr IV8SplitProxyNative.StdUInt64Array_New(int elementCount)
+            {
+                return StdUInt64Array_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdUInt64Array_GetElementCount(StdUInt64Array.Ptr pArray)
+            {
+                return StdUInt64Array_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt64Array_SetElementCount(StdUInt64Array.Ptr pArray, int elementCount)
+            {
+                StdUInt64Array_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdUInt64Array_GetData(StdUInt64Array.Ptr pArray)
+            {
+                return StdUInt64Array_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt64Array_Delete(StdUInt64Array.Ptr pArray)
+            {
+                StdUInt64Array_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdPtrArray methods
+
+            StdPtrArray.Ptr IV8SplitProxyNative.StdPtrArray_New(int elementCount)
+            {
+                return StdPtrArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdPtrArray_GetElementCount(StdPtrArray.Ptr pArray)
+            {
+                return StdPtrArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdPtrArray_SetElementCount(StdPtrArray.Ptr pArray, int elementCount)
+            {
+                StdPtrArray_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdPtrArray_GetData(StdPtrArray.Ptr pArray)
+            {
+                return StdPtrArray_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdPtrArray_Delete(StdPtrArray.Ptr pArray)
+            {
+                StdPtrArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdV8ValueArray methods
+
+            StdV8ValueArray.Ptr IV8SplitProxyNative.StdV8ValueArray_New(int elementCount)
+            {
+                return StdV8ValueArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdV8ValueArray_GetElementCount(StdV8ValueArray.Ptr pArray)
+            {
+                return StdV8ValueArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdV8ValueArray_SetElementCount(StdV8ValueArray.Ptr pArray, int elementCount)
+            {
+                StdV8ValueArray_SetElementCount(pArray, elementCount);
+            }
+
+            V8Value.Ptr IV8SplitProxyNative.StdV8ValueArray_GetData(StdV8ValueArray.Ptr pArray)
+            {
+                return StdV8ValueArray_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdV8ValueArray_Delete(StdV8ValueArray.Ptr pArray)
+            {
+                StdV8ValueArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region V8Value methods
+
+            V8Value.Ptr IV8SplitProxyNative.V8Value_New()
+            {
+                return V8Value_New();
+            }
+
+            void IV8SplitProxyNative.V8Value_SetNonexistent(V8Value.Ptr pV8Value)
+            {
+                V8Value_SetNonexistent(pV8Value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetUndefined(V8Value.Ptr pV8Value)
+            {
+                V8Value_SetUndefined(pV8Value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetNull(V8Value.Ptr pV8Value)
+            {
+                V8Value_SetNull(pV8Value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetBoolean(V8Value.Ptr pV8Value, bool value)
+            {
+                V8Value_SetBoolean(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetNumber(V8Value.Ptr pV8Value, double value)
+            {
+                V8Value_SetNumber(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetInt32(V8Value.Ptr pV8Value, int value)
+            {
+                V8Value_SetInt32(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetUInt32(V8Value.Ptr pV8Value, uint value)
+            {
+                V8Value_SetUInt32(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetString(V8Value.Ptr pV8Value, string value)
+            {
+                V8Value_SetString(pV8Value, value, value.Length);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetDateTime(V8Value.Ptr pV8Value, double value)
+            {
+                V8Value_SetDateTime(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetBigInt(V8Value.Ptr pV8Value, int signBit, byte[] bytes)
+            {
+                V8Value_SetBigInt(pV8Value, signBit, bytes, bytes.Length);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetV8Object(V8Value.Ptr pV8Value, V8Object.Handle hObject, V8Value.Subtype subtype)
+            {
+                V8Value_SetV8Object(pV8Value, hObject, subtype);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetHostObject(V8Value.Ptr pV8Value, IntPtr pObject)
+            {
+                V8Value_SetHostObject(pV8Value, pObject);
+            }
+
+            V8Value.Type IV8SplitProxyNative.V8Value_Decode(V8Value.Ptr pV8Value, out int intValue, out uint uintValue, out double doubleValue, out IntPtr ptrOrHandle)
+            {
+                return V8Value_Decode(pV8Value, out intValue, out uintValue, out doubleValue, out ptrOrHandle);
+            }
+
+            void IV8SplitProxyNative.V8Value_Delete(V8Value.Ptr pV8Value)
+            {
+                V8Value_Delete(pV8Value);
+            }
+
+            #endregion
+
+            #region V8CpuProfile methods
+
+            void IV8SplitProxyNative.V8CpuProfile_GetInfo(V8CpuProfile.Ptr pProfile, V8Entity.Handle hEntity, out string name, out ulong startTimestamp, out ulong endTimestamp, out int sampleCount, out V8CpuProfile.Node.Ptr pRootNode)
+            {
+                using (var nameScope = StdString.CreateScope())
+                {
+                    V8CpuProfile_GetInfo(pProfile, hEntity, nameScope.Value, out startTimestamp, out endTimestamp, out sampleCount, out pRootNode);
+                    name = StdString.GetValue(nameScope.Value);
+                }
+            }
+
+            bool IV8SplitProxyNative.V8CpuProfile_GetSample(V8CpuProfile.Ptr pProfile, int index, out ulong nodeId, out ulong timestamp)
+            {
+                return V8CpuProfile_GetSample(pProfile, index, out nodeId, out timestamp);
+            }
+
+            void IV8SplitProxyNative.V8CpuProfileNode_GetInfo(V8CpuProfile.Node.Ptr pNode, V8Entity.Handle hEntity, out ulong nodeId, out long scriptId, out string scriptName, out string functionName, out string bailoutReason, out long lineNumber, out long columnNumber, out ulong hitCount, out uint hitLineCount, out int childCount)
+            {
+                using (var scriptNameScope = StdString.CreateScope())
+                {
+                    using (var functionNameScope = StdString.CreateScope())
+                    {
+                        using (var bailoutReasonScope = StdString.CreateScope())
+                        {
+                            V8CpuProfileNode_GetInfo(pNode, hEntity, out nodeId, out scriptId, scriptNameScope.Value, functionNameScope.Value, bailoutReasonScope.Value, out lineNumber, out columnNumber, out hitCount, out hitLineCount, out childCount);
+                            scriptName = StdString.GetValue(scriptNameScope.Value);
+                            functionName = StdString.GetValue(functionNameScope.Value);
+                            bailoutReason = StdString.GetValue(bailoutReasonScope.Value);
+
+                        }
+                    }
+                }
+            }
+
+            bool IV8SplitProxyNative.V8CpuProfileNode_GetHitLines(V8CpuProfile.Node.Ptr pNode, out int[] lineNumbers, out uint[] hitCounts)
+            {
+                using (var lineNumbersScope = StdInt32Array.CreateScope())
+                {
+                    using (var hitCountsScope = StdUInt32Array.CreateScope())
+                    {
+                        var result = V8CpuProfileNode_GetHitLines(pNode, lineNumbersScope.Value, hitCountsScope.Value);
+                        lineNumbers = StdInt32Array.ToArray(lineNumbersScope.Value);
+                        hitCounts = StdUInt32Array.ToArray(hitCountsScope.Value);
+                        return result;
+                    }
+                }
+            }
+
+            V8CpuProfile.Node.Ptr IV8SplitProxyNative.V8CpuProfileNode_GetChildNode(V8CpuProfile.Node.Ptr pNode, int index)
+            {
+                return V8CpuProfileNode_GetChildNode(pNode, index);
+            }
+
+            #endregion
+
+            #region V8 isolate methods
+
+            V8Isolate.Handle IV8SplitProxyNative.V8Isolate_Create(string name, int maxNewSpaceSize, int maxOldSpaceSize, double heapExpansionMultiplier, ulong maxArrayBufferAllocation, bool enableDebugging, bool enableRemoteDebugging, bool enableDynamicModuleImports, int debugPort)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Isolate_Create(nameScope.Value, maxNewSpaceSize, maxOldSpaceSize, heapExpansionMultiplier, maxArrayBufferAllocation, enableDebugging, enableRemoteDebugging, enableDynamicModuleImports, debugPort);
+                }
+            }
+
+            V8Context.Handle IV8SplitProxyNative.V8Isolate_CreateContext(V8Isolate.Handle hIsolate, string name, bool enableDebugging, bool enableRemoteDebugging, bool disableGlobalMembers, bool enableDateTimeConversion, bool enableDynamicModuleImports, int debugPort)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Isolate_CreateContext(hIsolate, nameScope.Value, enableDebugging, enableRemoteDebugging, disableGlobalMembers, enableDateTimeConversion, enableDynamicModuleImports, debugPort);
+                }
+            }
+
+            UIntPtr IV8SplitProxyNative.V8Isolate_GetMaxHeapSize(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetMaxHeapSize(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetMaxHeapSize(V8Isolate.Handle hIsolate, UIntPtr size)
+            {
+                V8Isolate_SetMaxHeapSize(hIsolate, size);
+            }
+
+            double IV8SplitProxyNative.V8Isolate_GetHeapSizeSampleInterval(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetHeapSizeSampleInterval(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetHeapSizeSampleInterval(V8Isolate.Handle hIsolate, double milliseconds)
+            {
+                V8Isolate_SetHeapSizeSampleInterval(hIsolate, milliseconds);
+            }
+
+            UIntPtr IV8SplitProxyNative.V8Isolate_GetMaxStackUsage(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetMaxStackUsage(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetMaxStackUsage(V8Isolate.Handle hIsolate, UIntPtr size)
+            {
+                V8Isolate_SetMaxStackUsage(hIsolate, size);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_AwaitDebuggerAndPause(V8Isolate.Handle hIsolate)
+            {
+                V8Isolate_AwaitDebuggerAndPause(hIsolate);
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Isolate_Compile(V8Isolate.Handle hIsolate, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            return V8Isolate_Compile(hIsolate, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value);
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Isolate_CompileProducingCache(V8Isolate.Handle hIsolate, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, out byte[] cacheBytes)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope())
+                            {
+                                var hScript = V8Isolate_CompileProducingCache(hIsolate, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value);
+                                cacheBytes = StdByteArray.ToArray(cacheBytesScope.Value);
+                                return hScript;
+                            }
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Isolate_CompileConsumingCache(V8Isolate.Handle hIsolate, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, byte[] cacheBytes, out bool cacheAccepted)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope(cacheBytes))
+                            {
+                                return V8Isolate_CompileConsumingCache(hIsolate, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value, out cacheAccepted);
+                            }
+                        }
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_GetHeapStatistics(V8Isolate.Handle hIsolate, out ulong totalHeapSize, out ulong totalHeapSizeExecutable, out ulong totalPhysicalSize, out ulong usedHeapSize, out ulong heapSizeLimit)
+            {
+                V8Isolate_GetHeapStatistics(hIsolate, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out usedHeapSize, out heapSizeLimit);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_GetStatistics(V8Isolate.Handle hIsolate, out ulong scriptCount, out ulong scriptCacheSize, out ulong moduleCount, out ulong[] postedTaskCounts, out ulong[] invokedTaskCounts)
+            {
+                using (var postedTaskCountsScope = StdUInt64Array.CreateScope())
+                {
+                    using (var invokedTaskCountsScope = StdUInt64Array.CreateScope())
+                    {
+                        V8Isolate_GetStatistics(hIsolate, out scriptCount, out scriptCacheSize, out moduleCount, postedTaskCountsScope.Value, invokedTaskCountsScope.Value);
+                        postedTaskCounts = StdUInt64Array.ToArray(postedTaskCountsScope.Value);
+                        invokedTaskCounts = StdUInt64Array.ToArray(invokedTaskCountsScope.Value);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_CollectGarbage(V8Isolate.Handle hIsolate, bool exhaustive)
+            {
+                V8Isolate_CollectGarbage(hIsolate, exhaustive);
+            }
+
+            bool IV8SplitProxyNative.V8Isolate_BeginCpuProfile(V8Isolate.Handle hIsolate, string name, bool recordSamples)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Isolate_BeginCpuProfile(hIsolate, nameScope.Value, recordSamples);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_EndCpuProfile(V8Isolate.Handle hIsolate, string name, IntPtr pAction)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    V8Isolate_EndCpuProfile(hIsolate, nameScope.Value, pAction);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_CollectCpuProfileSample(V8Isolate.Handle hIsolate)
+            {
+                V8Isolate_CollectCpuProfileSample(hIsolate);
+            }
+
+            uint IV8SplitProxyNative.V8Isolate_GetCpuProfileSampleInterval(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetCpuProfileSampleInterval(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetCpuProfileSampleInterval(V8Isolate.Handle hIsolate, uint value)
+            {
+                V8Isolate_SetCpuProfileSampleInterval(hIsolate, value);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_WriteHeapSnapshot(V8Isolate.Handle hIsolate, IntPtr pStream)
+            {
+                V8Isolate_WriteHeapSnapshot(hIsolate, pStream);
+            }
+
+            #endregion
+
+            #region V8 context methods
+
+            UIntPtr IV8SplitProxyNative.V8Context_GetMaxIsolateHeapSize(V8Context.Handle hContext)
+            {
+                return V8Context_GetMaxIsolateHeapSize(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetMaxIsolateHeapSize(V8Context.Handle hContext, UIntPtr size)
+            {
+                V8Context_SetMaxIsolateHeapSize(hContext, size);
+            }
+
+            double IV8SplitProxyNative.V8Context_GetIsolateHeapSizeSampleInterval(V8Context.Handle hContext)
+            {
+                return V8Context_GetIsolateHeapSizeSampleInterval(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetIsolateHeapSizeSampleInterval(V8Context.Handle hContext, double milliseconds)
+            {
+                V8Context_SetIsolateHeapSizeSampleInterval(hContext, milliseconds);
+            }
+
+            UIntPtr IV8SplitProxyNative.V8Context_GetMaxIsolateStackUsage(V8Context.Handle hContext)
+            {
+                return V8Context_GetMaxIsolateStackUsage(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetMaxIsolateStackUsage(V8Context.Handle hContext, UIntPtr size)
+            {
+                V8Context_SetMaxIsolateStackUsage(hContext, size);
+            }
+
+            void IV8SplitProxyNative.V8Context_InvokeWithLock(V8Context.Handle hContext, IntPtr pAction)
+            {
+                V8Context_InvokeWithLock(hContext, pAction);
+            }
+
+            object IV8SplitProxyNative.V8Context_GetRootItem(V8Context.Handle hContext)
+            {
+                using (var itemScope = V8Value.CreateScope())
+                {
+                    V8Context_GetRootItem(hContext, itemScope.Value);
+                    return V8Value.Get(itemScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_AddGlobalItem(V8Context.Handle hContext, string name, object value, bool globalMembers)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var valueScope = V8Value.CreateScope(value))
+                    {
+                        V8Context_AddGlobalItem(hContext, nameScope.Value, valueScope.Value, globalMembers);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_AwaitDebuggerAndPause(V8Context.Handle hContext)
+            {
+                V8Context_AwaitDebuggerAndPause(hContext);
+            }
+
+            object IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, bool evaluate)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var resultScope = V8Value.CreateScope())
+                            {
+                                V8Context_ExecuteCode(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, evaluate, resultScope.Value);
+                                return V8Value.Get(resultScope.Value);
+                            }
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            return V8Context_Compile(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value);
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Context_CompileProducingCache(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, out byte[] cacheBytes)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope())
+                            {
+                                var hScript = V8Context_CompileProducingCache(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value);
+                                cacheBytes = StdByteArray.ToArray(cacheBytesScope.Value);
+                                return hScript;
+                            }
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Context_CompileConsumingCache(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, byte[] cacheBytes, out bool cacheAccepted)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope(cacheBytes))
+                            {
+                                return V8Context_CompileConsumingCache(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value, out cacheAccepted);
+                            }
+                        }
+                    }
+                }
+            }
+
+            object IV8SplitProxyNative.V8Context_ExecuteScript(V8Context.Handle hContext, V8Script.Handle hScript, bool evaluate)
+            {
+                using (var resultScope = V8Value.CreateScope())
+                {
+                    V8Context_ExecuteScript(hContext, hScript, evaluate, resultScope.Value);
+                    return V8Value.Get(resultScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_Interrupt(V8Context.Handle hContext)
+            {
+                V8Context_Interrupt(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_GetIsolateHeapStatistics(V8Context.Handle hContext, out ulong totalHeapSize, out ulong totalHeapSizeExecutable, out ulong totalPhysicalSize, out ulong usedHeapSize, out ulong heapSizeLimit)
+            {
+                V8Context_GetIsolateHeapStatistics(hContext, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out usedHeapSize, out heapSizeLimit);
+            }
+
+            void IV8SplitProxyNative.V8Context_GetIsolateStatistics(V8Context.Handle hContext, out ulong scriptCount, out ulong scriptCacheSize, out ulong moduleCount, out ulong[] postedTaskCounts, out ulong[] invokedTaskCounts)
+            {
+                using (var postedTaskCountsScope = StdUInt64Array.CreateScope())
+                {
+                    using (var invokedTaskCountsScope = StdUInt64Array.CreateScope())
+                    {
+                        V8Context_GetIsolateStatistics(hContext, out scriptCount, out scriptCacheSize, out moduleCount, postedTaskCountsScope.Value, invokedTaskCountsScope.Value);
+                        postedTaskCounts = StdUInt64Array.ToArray(postedTaskCountsScope.Value);
+                        invokedTaskCounts = StdUInt64Array.ToArray(invokedTaskCountsScope.Value);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_GetStatistics(V8Context.Handle hContext, out ulong scriptCount, out ulong moduleCount, out ulong moduleCacheSize)
+            {
+                V8Context_GetStatistics(hContext, out scriptCount, out moduleCount, out moduleCacheSize);
+            }
+
+            void IV8SplitProxyNative.V8Context_CollectGarbage(V8Context.Handle hContext, bool exhaustive)
+            {
+                V8Context_CollectGarbage(hContext, exhaustive);
+            }
+
+            void IV8SplitProxyNative.V8Context_OnAccessSettingsChanged(V8Context.Handle hContext)
+            {
+                V8Context_OnAccessSettingsChanged(hContext);
+            }
+
+            bool IV8SplitProxyNative.V8Context_BeginCpuProfile(V8Context.Handle hContext, string name, bool recordSamples)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Context_BeginCpuProfile(hContext, nameScope.Value, recordSamples);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_EndCpuProfile(V8Context.Handle hContext, string name, IntPtr pAction)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    V8Context_EndCpuProfile(hContext, nameScope.Value, pAction);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_CollectCpuProfileSample(V8Context.Handle hContext)
+            {
+                V8Context_CollectCpuProfileSample(hContext);
+            }
+
+            uint IV8SplitProxyNative.V8Context_GetCpuProfileSampleInterval(V8Context.Handle hContext)
+            {
+                return V8Context_GetCpuProfileSampleInterval(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetCpuProfileSampleInterval(V8Context.Handle hContext, uint value)
+            {
+                V8Context_SetCpuProfileSampleInterval(hContext, value);
+            }
+
+            void IV8SplitProxyNative.V8Context_WriteIsolateHeapSnapshot(V8Context.Handle hContext, IntPtr pStream)
+            {
+                V8Context_WriteIsolateHeapSnapshot(hContext, pStream);
+            }
+
+            #endregion
+
+            #region V8 object methods
+
+            object IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, string name)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var valueScope = V8Value.CreateScope())
+                    {
+                        V8Object_GetNamedProperty(hObject, nameScope.Value, valueScope.Value);
+                        return V8Value.Get(valueScope.Value);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_SetNamedProperty(V8Object.Handle hObject, string name, object value)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var valueScope = V8Value.CreateScope(value))
+                    {
+                        V8Object_SetNamedProperty(hObject, nameScope.Value, valueScope.Value);
+                    }
+                }
+            }
+
+            bool IV8SplitProxyNative.V8Object_DeleteNamedProperty(V8Object.Handle hObject, string name)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Object_DeleteNamedProperty(hObject, nameScope.Value);
+                }
+            }
+
+            string[] IV8SplitProxyNative.V8Object_GetPropertyNames(V8Object.Handle hObject)
+            {
+                using (var namesScope = StdStringArray.CreateScope())
+                {
+                    V8Object_GetPropertyNames(hObject, namesScope.Value);
+                    return StdStringArray.ToArray(namesScope.Value);
+                }
+            }
+
+            object IV8SplitProxyNative.V8Object_GetIndexedProperty(V8Object.Handle hObject, int index)
+            {
+                using (var valueScope = V8Value.CreateScope())
+                {
+                    V8Object_GetIndexedProperty(hObject, index, valueScope.Value);
+                    return V8Value.Get(valueScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_SetIndexedProperty(V8Object.Handle hObject, int index, object value)
+            {
+                using (var valueScope = V8Value.CreateScope(value))
+                {
+                    V8Object_SetIndexedProperty(hObject, index, valueScope.Value);
+                }
+            }
+
+            bool IV8SplitProxyNative.V8Object_DeleteIndexedProperty(V8Object.Handle hObject, int index)
+            {
+                return V8Object_DeleteIndexedProperty(hObject, index);
+            }
+
+            int[] IV8SplitProxyNative.V8Object_GetPropertyIndices(V8Object.Handle hObject)
+            {
+                using (var indicesScope = StdInt32Array.CreateScope())
+                {
+                    V8Object_GetPropertyIndices(hObject, indicesScope.Value);
+                    return StdInt32Array.ToArray(indicesScope.Value);
+                }
+            }
+
+            object IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, object[] args)
+            {
+                using (var argsScope = StdV8ValueArray.CreateScope(args))
+                {
+                    using (var resultScope = V8Value.CreateScope())
+                    {
+                        V8Object_Invoke(hObject, asConstructor, argsScope.Value, resultScope.Value);
+                        return V8Value.Get(resultScope.Value);
+                    }
+                }
+            }
+
+            object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var argsScope = StdV8ValueArray.CreateScope(args))
+                    {
+                        using (var resultScope = V8Value.CreateScope())
+                        {
+                            V8Object_InvokeMethod(hObject, nameScope.Value, argsScope.Value, resultScope.Value);
+                            return V8Value.Get(resultScope.Value);
+                        }
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, out IV8Object arrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                using (var arrayBufferScope = V8Value.CreateScope())
+                {
+                    V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
+                    arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
+            {
+                V8Object_InvokeWithArrayBufferOrViewData(hObject, pAction);
+            }
+
+            #endregion
+
+            #region V8 debug callback methods
+
+            void IV8SplitProxyNative.V8DebugCallback_ConnectClient(V8DebugCallback.Handle hCallback)
+            {
+                V8DebugCallback_ConnectClient(hCallback);
+            }
+
+            void IV8SplitProxyNative.V8DebugCallback_SendCommand(V8DebugCallback.Handle hCallback, string command)
+            {
+                using (var commandScope = StdString.CreateScope(command))
+                {
+                    V8DebugCallback_SendCommand(hCallback, commandScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8DebugCallback_DisconnectClient(V8DebugCallback.Handle hCallback)
+            {
+                V8DebugCallback_DisconnectClient(hCallback);
+            }
+
+            #endregion
+
+            #region native callback methods
+
+            void IV8SplitProxyNative.NativeCallback_Invoke(NativeCallback.Handle hCallback)
+            {
+                NativeCallback_Invoke(hCallback);
+            }
+
+            #endregion
+
+            #region V8 entity cleanup
+
+            void IV8SplitProxyNative.V8Entity_Release(V8Entity.Handle hEntity)
+            {
+                V8Entity_Release(hEntity);
+            }
+
+            void IV8SplitProxyNative.V8Entity_DestroyHandle(V8Entity.Handle hEntity)
+            {
+                V8Entity_DestroyHandle(hEntity);
+            }
+
+            #endregion
+
+            #region error handling
+
+            void IV8SplitProxyNative.HostException_Schedule(string message, object exception)
+            {
+                using (var messageScope = StdString.CreateScope(message))
+                {
+                    using (var exceptionScope = V8Value.CreateScope(exception))
+                    {
+                        HostException_Schedule(messageScope.Value, exceptionScope.Value);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region unit test support
+
+            UIntPtr IV8SplitProxyNative.V8UnitTestSupport_GetTextDigest(string value)
+            {
+                using (var valueScope = StdString.CreateScope(value))
+                {
+                    return V8UnitTestSupport_GetTextDigest(valueScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8UnitTestSupport_GetStatistics(out ulong isolateCount, out ulong contextCount)
+            {
+                V8UnitTestSupport_GetStatistics(out isolateCount, out contextCount);
+            }
+
+            #endregion
+
+            #endregion
+
+            #region native methods
+
+            #region initialization
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr V8SplitProxyManaged_SetMethodTable(
+                [In] IntPtr pMethodTable
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Environment_InitializeICU(
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string dataPath
+            );
+
+            #endregion
+
+            #region StdString methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdString.Ptr StdString_New(
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdString_GetValue(
+                [In] StdString.Ptr pString,
+                [Out] out int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdString_SetValue(
+                [In] StdString.Ptr pString,
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdString_Delete(
+                [In] StdString.Ptr pString
+            );
+
+            #endregion
+
+            #region StdStringArray methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdStringArray.Ptr StdStringArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdStringArray_GetElementCount(
+                [In] StdStringArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdStringArray_SetElementCount(
+                [In] StdStringArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdStringArray_GetElement(
+                [In] StdStringArray.Ptr pArray,
+                [In] int index,
+                [Out] out int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdStringArray_SetElement(
+                [In] StdStringArray.Ptr pArray,
+                [In] int index,
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdStringArray_Delete(
+                [In] StdStringArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdByteArray methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdByteArray.Ptr StdByteArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdByteArray_GetElementCount(
+                [In] StdByteArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdByteArray_SetElementCount(
+                [In] StdByteArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdByteArray_GetData(
+                [In] StdByteArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdByteArray_Delete(
+                [In] StdByteArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdInt32Array methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdInt32Array.Ptr StdInt32Array_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdInt32Array_GetElementCount(
+                [In] StdInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdInt32Array_SetElementCount(
+                [In] StdInt32Array.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdInt32Array_GetData(
+                [In] StdInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdInt32Array_Delete(
+                [In] StdInt32Array.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdUInt32Array methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdUInt32Array.Ptr StdUInt32Array_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdUInt32Array_GetElementCount(
+                [In] StdUInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt32Array_SetElementCount(
+                [In] StdUInt32Array.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdUInt32Array_GetData(
+                [In] StdUInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt32Array_Delete(
+                [In] StdUInt32Array.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdUInt64Array methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdUInt64Array.Ptr StdUInt64Array_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdUInt64Array_GetElementCount(
+                [In] StdUInt64Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt64Array_SetElementCount(
+                [In] StdUInt64Array.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdUInt64Array_GetData(
+                [In] StdUInt64Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt64Array_Delete(
+                [In] StdUInt64Array.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdPtrArray methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdPtrArray.Ptr StdPtrArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdPtrArray_GetElementCount(
+                [In] StdPtrArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdPtrArray_SetElementCount(
+                [In] StdPtrArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdPtrArray_GetData(
+                [In] StdPtrArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdPtrArray_Delete(
+                [In] StdPtrArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdV8ValueArray methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdV8ValueArray.Ptr StdV8ValueArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdV8ValueArray_GetElementCount(
+                [In] StdV8ValueArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdV8ValueArray_SetElementCount(
+                [In] StdV8ValueArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Value.Ptr StdV8ValueArray_GetData(
+                [In] StdV8ValueArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdV8ValueArray_Delete(
+                [In] StdV8ValueArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region V8Value methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Value.Ptr V8Value_New();
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetNonexistent(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetUndefined(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetNull(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetBoolean(
+                [In] V8Value.Ptr pV8Value,
+                [In] [MarshalAs(UnmanagedType.I1)] bool value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetNumber(
+                [In] V8Value.Ptr pV8Value,
+                [In] double value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetInt32(
+                [In] V8Value.Ptr pV8Value,
+                [In] int value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetUInt32(
+                [In] V8Value.Ptr pV8Value,
+                [In] uint value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetString(
+                [In] V8Value.Ptr pV8Value,
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetDateTime(
+                [In] V8Value.Ptr pV8Value,
+                [In] double value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetBigInt(
+                [In] V8Value.Ptr pV8Value,
+                [In] int signBit,
+                [In] [MarshalAs(UnmanagedType.LPArray)] byte[] bytes,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetV8Object(
+                [In] V8Value.Ptr pV8Value,
+                [In] V8Object.Handle hObject,
+                [In] V8Value.Subtype subtype
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetHostObject(
+                [In] V8Value.Ptr pV8Value,
+                [In] IntPtr pObject
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Value.Type V8Value_Decode(
+                [In] V8Value.Ptr pV8Value,
+                [Out] out int intValue,
+                [Out] out uint uintValue,
+                [Out] out double doubleValue,
+                [Out] out IntPtr ptrOrHandle
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_Delete(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            #endregion
+
+            #region V8CpuProfile methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8CpuProfile_GetInfo(
+                [In] V8CpuProfile.Ptr pProfile,
+                [In] V8Entity.Handle hEntity,
+                [In] StdString.Ptr pName,
+                [Out] out ulong startTimestamp,
+                [Out] out ulong endTimestamp,
+                [Out] out int sampleCount,
+                [Out] out V8CpuProfile.Node.Ptr pRootNode
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8CpuProfile_GetSample(
+                [In] V8CpuProfile.Ptr pProfile,
+                [In] int index,
+                [Out] out ulong nodeId,
+                [Out] out ulong timestamp
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8CpuProfileNode_GetInfo(
+                [In] V8CpuProfile.Node.Ptr pNode,
+                [In] V8Entity.Handle hEntity,
+                [Out] out ulong nodeId,
+                [Out] out long scriptId,
+                [In] StdString.Ptr pScriptName,
+                [In] StdString.Ptr pFunctionName,
+                [In] StdString.Ptr pBailoutReason,
+                [Out] out long lineNumber,
+                [Out] out long columnNumber,
+                [Out] out ulong hitCount,
+                [Out] out uint hitLineCount,
+                [Out] out int childCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8CpuProfileNode_GetHitLines(
+                [In] V8CpuProfile.Node.Ptr pNode,
+                [In] StdInt32Array.Ptr pLineNumbers,
+                [In] StdUInt32Array.Ptr pHitCounts
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8CpuProfile.Node.Ptr V8CpuProfileNode_GetChildNode(
+                [In] V8CpuProfile.Node.Ptr pNode,
+                [In] int index
+            );
+
+            #endregion
+
+            #region V8 isolate methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Isolate.Handle V8Isolate_Create(
+                [In] StdString.Ptr pName,
+                [In] int maxNewSpaceSize,
+                [In] int maxOldSpaceSize,
+                [In] double heapExpansionMultiplier,
+                [In] ulong maxArrayBufferAllocation,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableRemoteDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDynamicModuleImports,
+                [In] int debugPort
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Context.Handle V8Isolate_CreateContext(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pName,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableRemoteDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool disableGlobalMembers,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDateTimeConversion,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDynamicModuleImports,
+                [In] int debugPort
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Isolate_GetMaxHeapSize(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetMaxHeapSize(
+                [In] V8Isolate.Handle hIsolate,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern double V8Isolate_GetHeapSizeSampleInterval(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetHeapSizeSampleInterval(
+                [In] V8Isolate.Handle hIsolate,
+                [In] double milliseconds
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Isolate_GetMaxStackUsage(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetMaxStackUsage(
+                [In] V8Isolate.Handle hIsolate,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_AwaitDebuggerAndPause(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Isolate_Compile(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Isolate_CompileProducingCache(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Isolate_CompileConsumingCache(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes,
+                [Out] [MarshalAs(UnmanagedType.I1)] out bool cacheAccepted
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_GetHeapStatistics(
+                [In] V8Isolate.Handle hIsolate,
+                [Out] out ulong totalHeapSize,
+                [Out] out ulong totalHeapSizeExecutable,
+                [Out] out ulong totalPhysicalSize,
+                [Out] out ulong usedHeapSize,
+                [Out] out ulong heapSizeLimit
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_GetStatistics(
+                [In] V8Isolate.Handle hIsolate,
+                [Out] out ulong scriptCount,
+                [Out] out ulong scriptCacheSize,
+                [Out] out ulong moduleCount,
+                [In] StdUInt64Array.Ptr pPostedTaskCounts,
+                [In] StdUInt64Array.Ptr pInvokedTaskCounts
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_CollectGarbage(
+                [In] V8Isolate.Handle hIsolate,
+                [In] [MarshalAs(UnmanagedType.I1)] bool exhaustive
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Isolate_BeginCpuProfile(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pName,
+                [In] [MarshalAs(UnmanagedType.I1)] bool recordSamples
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_EndCpuProfile(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pName,
+                [In] IntPtr pAction
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_CollectCpuProfileSample(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern uint V8Isolate_GetCpuProfileSampleInterval(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetCpuProfileSampleInterval(
+                [In] V8Isolate.Handle hIsolate,
+                [In] uint value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_WriteHeapSnapshot(
+                [In] V8Isolate.Handle hIsolate,
+                [In] IntPtr pStream
+            );
+
+            #endregion
+
+            #region V8 context methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Context_GetMaxIsolateHeapSize(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetMaxIsolateHeapSize(
+                [In] V8Context.Handle hContext,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern double V8Context_GetIsolateHeapSizeSampleInterval(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetIsolateHeapSizeSampleInterval(
+                [In] V8Context.Handle hContext,
+                [In] double milliseconds
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Context_GetMaxIsolateStackUsage(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetMaxIsolateStackUsage(
+                [In] V8Context.Handle hContext,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_InvokeWithLock(
+                [In] V8Context.Handle hContext,
+                [In] IntPtr pAction
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetRootItem(
+                [In] V8Context.Handle hContext,
+                [In] V8Value.Ptr pItem
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_AddGlobalItem(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pName,
+                [In] V8Value.Ptr pValue,
+                [In] [MarshalAs(UnmanagedType.I1)] bool globalMembers
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_AwaitDebuggerAndPause(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_ExecuteCode(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] [MarshalAs(UnmanagedType.I1)] bool evaluate,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Context_Compile(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Context_CompileProducingCache(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Context_CompileConsumingCache(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes,
+                [Out] [MarshalAs(UnmanagedType.I1)] out bool cacheAccepted
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_ExecuteScript(
+                [In] V8Context.Handle hContext,
+                [In] V8Script.Handle hScript,
+                [In] [MarshalAs(UnmanagedType.I1)] bool evaluate,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_Interrupt(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetIsolateHeapStatistics(
+                [In] V8Context.Handle hContext,
+                [Out] out ulong totalHeapSize,
+                [Out] out ulong totalHeapSizeExecutable,
+                [Out] out ulong totalPhysicalSize,
+                [Out] out ulong usedHeapSize,
+                [Out] out ulong heapSizeLimit
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetIsolateStatistics(
+                [In] V8Context.Handle hContext,
+                [Out] out ulong scriptCount,
+                [Out] out ulong scriptCacheSize,
+                [Out] out ulong moduleCount,
+                [In] StdUInt64Array.Ptr pPostedTaskCounts,
+                [In] StdUInt64Array.Ptr pInvokedTaskCounts
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetStatistics(
+                [In] V8Context.Handle hContext,
+                [Out] out ulong scriptCount,
+                [Out] out ulong moduleCount,
+                [Out] out ulong moduleCacheSize
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_CollectGarbage(
+                [In] V8Context.Handle hContext,
+                [In] [MarshalAs(UnmanagedType.I1)] bool exhaustive
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_OnAccessSettingsChanged(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Context_BeginCpuProfile(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pName,
+                [In] [MarshalAs(UnmanagedType.I1)] bool recordSamples
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_EndCpuProfile(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pName,
+                [In] IntPtr pAction
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_CollectCpuProfileSample(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern uint V8Context_GetCpuProfileSampleInterval(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetCpuProfileSampleInterval(
+                [In] V8Context.Handle hContext,
+                [In] uint value
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_WriteIsolateHeapSnapshot(
+                [In] V8Context.Handle hContext,
+                [In] IntPtr pStream
+            );
+
+            #endregion
+
+            #region V8 object methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetNamedProperty(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_SetNamedProperty(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Object_DeleteNamedProperty(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetPropertyNames(
+                [In] V8Object.Handle hObject,
+                [In] StdStringArray.Ptr pNames
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetIndexedProperty(
+                [In] V8Object.Handle hObject,
+                [In] int index,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_SetIndexedProperty(
+                [In] V8Object.Handle hObject,
+                [In] int index,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Object_DeleteIndexedProperty(
+                [In] V8Object.Handle hObject,
+                [In] int index
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetPropertyIndices(
+                [In] V8Object.Handle hObject,
+                [In] StdInt32Array.Ptr pIndices
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_Invoke(
+                [In] V8Object.Handle hObject,
+                [In] [MarshalAs(UnmanagedType.I1)] bool asConstructor,
+                [In] StdV8ValueArray.Ptr pArgs,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_InvokeMethod(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName,
+                [In] StdV8ValueArray.Ptr pArgs,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetArrayBufferOrViewInfo(
+                [In] V8Object.Handle hObject,
+                [In] V8Value.Ptr pArrayBuffer,
+                [Out] out ulong offset,
+                [Out] out ulong size,
+                [Out] out ulong length
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_InvokeWithArrayBufferOrViewData(
+                [In] V8Object.Handle hObject,
+                [In] IntPtr pAction
+            );
+
+            #endregion
+
+            #region V8 debug callback methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8DebugCallback_ConnectClient(
+                [In] V8DebugCallback.Handle hCallback
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8DebugCallback_SendCommand(
+                [In] V8DebugCallback.Handle hCallback,
+                [In] StdString.Ptr pCommand
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8DebugCallback_DisconnectClient(
+                [In] V8DebugCallback.Handle hCallback
+            );
+
+            #endregion
+
+            #region native callback methods
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void NativeCallback_Invoke(
+                [In] NativeCallback.Handle hCallback
+            );
+
+            #endregion
+
+            #region V8 entity cleanup
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Entity_Release(
+                [In] V8Entity.Handle hEntity
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Entity_DestroyHandle(
+                [In] V8Entity.Handle hEntity
+            );
+
+            #endregion
+
+            #region error handling
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void HostException_Schedule(
+                [In] StdString.Ptr pMessage,
+                [In] V8Value.Ptr pException
+            );
+
+            #endregion
+
+            #region unit test support
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8UnitTestSupport_GetTextDigest(
+                [In] StdString.Ptr pString
+            );
+
+            [DllImport("ClearScriptV8.android-arm64.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8UnitTestSupport_GetStatistics(
+                [Out] out ulong isolateCount,
+                [Out] out ulong contextCount
+            );
+
+            #endregion
+
+            #endregion
+        }
+
+        #endregion
+
+        
+
+        #region Nested type: Impl_Android_Arm
+
+        private sealed class Impl_Android_Arm : IV8SplitProxyNative
+        {
+            public static readonly IV8SplitProxyNative Instance = new Impl_Android_Arm();
+
+            #region IV8SplitProxyNative implementation
+
+            #region initialization
+
+            IntPtr IV8SplitProxyNative.V8SplitProxyManaged_SetMethodTable(IntPtr pMethodTable)
+            {
+                return V8SplitProxyManaged_SetMethodTable(pMethodTable);
+            }
+
+            void IV8SplitProxyNative.V8Environment_InitializeICU(string dataPath)
+            {
+                V8Environment_InitializeICU(dataPath);
+            }
+
+            #endregion
+
+            #region StdString methods
+
+            StdString.Ptr IV8SplitProxyNative.StdString_New(string value)
+            {
+                return StdString_New(value, value.Length);
+            }
+
+            string IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString)
+            {
+                var pValue = StdString_GetValue(pString, out var length);
+                return Marshal.PtrToStringUni(pValue, length);
+            }
+
+            void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
+            {
+                StdString_SetValue(pString, value, value.Length);
+            }
+
+            void IV8SplitProxyNative.StdString_Delete(StdString.Ptr pString)
+            {
+                StdString_Delete(pString);
+            }
+
+            #endregion
+
+            #region StdStringArray methods
+
+            StdStringArray.Ptr IV8SplitProxyNative.StdStringArray_New(int elementCount)
+            {
+                return StdStringArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdStringArray_GetElementCount(StdStringArray.Ptr pArray)
+            {
+                return StdStringArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdStringArray_SetElementCount(StdStringArray.Ptr pArray, int elementCount)
+            {
+                StdStringArray_SetElementCount(pArray, elementCount);
+            }
+
+            string IV8SplitProxyNative.StdStringArray_GetElement(StdStringArray.Ptr pArray, int index)
+            {
+                var pValue = StdStringArray_GetElement(pArray, index, out var length);
+                return Marshal.PtrToStringUni(pValue, length);
+            }
+
+            void IV8SplitProxyNative.StdStringArray_SetElement(StdStringArray.Ptr pArray, int index, string value)
+            {
+                StdStringArray_SetElement(pArray, index, value, value.Length);
+            }
+
+            void IV8SplitProxyNative.StdStringArray_Delete(StdStringArray.Ptr pArray)
+            {
+                StdStringArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdByteArray methods
+
+            StdByteArray.Ptr IV8SplitProxyNative.StdByteArray_New(int elementCount)
+            {
+                return StdByteArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdByteArray_GetElementCount(StdByteArray.Ptr pArray)
+            {
+                return StdByteArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdByteArray_SetElementCount(StdByteArray.Ptr pArray, int elementCount)
+            {
+                StdByteArray_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdByteArray_GetData(StdByteArray.Ptr pArray)
+            {
+                return StdByteArray_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdByteArray_Delete(StdByteArray.Ptr pArray)
+            {
+                StdByteArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdInt32Array methods
+
+            StdInt32Array.Ptr IV8SplitProxyNative.StdInt32Array_New(int elementCount)
+            {
+                return StdInt32Array_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdInt32Array_GetElementCount(StdInt32Array.Ptr pArray)
+            {
+                return StdInt32Array_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdInt32Array_SetElementCount(StdInt32Array.Ptr pArray, int elementCount)
+            {
+                StdInt32Array_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdInt32Array_GetData(StdInt32Array.Ptr pArray)
+            {
+                return StdInt32Array_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdInt32Array_Delete(StdInt32Array.Ptr pArray)
+            {
+                StdInt32Array_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdUInt32Array methods
+
+            StdUInt32Array.Ptr IV8SplitProxyNative.StdUInt32Array_New(int elementCount)
+            {
+                return StdUInt32Array_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdUInt32Array_GetElementCount(StdUInt32Array.Ptr pArray)
+            {
+                return StdUInt32Array_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt32Array_SetElementCount(StdUInt32Array.Ptr pArray, int elementCount)
+            {
+                StdUInt32Array_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdUInt32Array_GetData(StdUInt32Array.Ptr pArray)
+            {
+                return StdUInt32Array_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt32Array_Delete(StdUInt32Array.Ptr pArray)
+            {
+                StdUInt32Array_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdUInt64Array methods
+
+            StdUInt64Array.Ptr IV8SplitProxyNative.StdUInt64Array_New(int elementCount)
+            {
+                return StdUInt64Array_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdUInt64Array_GetElementCount(StdUInt64Array.Ptr pArray)
+            {
+                return StdUInt64Array_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt64Array_SetElementCount(StdUInt64Array.Ptr pArray, int elementCount)
+            {
+                StdUInt64Array_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdUInt64Array_GetData(StdUInt64Array.Ptr pArray)
+            {
+                return StdUInt64Array_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdUInt64Array_Delete(StdUInt64Array.Ptr pArray)
+            {
+                StdUInt64Array_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdPtrArray methods
+
+            StdPtrArray.Ptr IV8SplitProxyNative.StdPtrArray_New(int elementCount)
+            {
+                return StdPtrArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdPtrArray_GetElementCount(StdPtrArray.Ptr pArray)
+            {
+                return StdPtrArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdPtrArray_SetElementCount(StdPtrArray.Ptr pArray, int elementCount)
+            {
+                StdPtrArray_SetElementCount(pArray, elementCount);
+            }
+
+            IntPtr IV8SplitProxyNative.StdPtrArray_GetData(StdPtrArray.Ptr pArray)
+            {
+                return StdPtrArray_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdPtrArray_Delete(StdPtrArray.Ptr pArray)
+            {
+                StdPtrArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region StdV8ValueArray methods
+
+            StdV8ValueArray.Ptr IV8SplitProxyNative.StdV8ValueArray_New(int elementCount)
+            {
+                return StdV8ValueArray_New(elementCount);
+            }
+
+            int IV8SplitProxyNative.StdV8ValueArray_GetElementCount(StdV8ValueArray.Ptr pArray)
+            {
+                return StdV8ValueArray_GetElementCount(pArray);
+            }
+
+            void IV8SplitProxyNative.StdV8ValueArray_SetElementCount(StdV8ValueArray.Ptr pArray, int elementCount)
+            {
+                StdV8ValueArray_SetElementCount(pArray, elementCount);
+            }
+
+            V8Value.Ptr IV8SplitProxyNative.StdV8ValueArray_GetData(StdV8ValueArray.Ptr pArray)
+            {
+                return StdV8ValueArray_GetData(pArray);
+            }
+
+            void IV8SplitProxyNative.StdV8ValueArray_Delete(StdV8ValueArray.Ptr pArray)
+            {
+                StdV8ValueArray_Delete(pArray);
+            }
+
+            #endregion
+
+            #region V8Value methods
+
+            V8Value.Ptr IV8SplitProxyNative.V8Value_New()
+            {
+                return V8Value_New();
+            }
+
+            void IV8SplitProxyNative.V8Value_SetNonexistent(V8Value.Ptr pV8Value)
+            {
+                V8Value_SetNonexistent(pV8Value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetUndefined(V8Value.Ptr pV8Value)
+            {
+                V8Value_SetUndefined(pV8Value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetNull(V8Value.Ptr pV8Value)
+            {
+                V8Value_SetNull(pV8Value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetBoolean(V8Value.Ptr pV8Value, bool value)
+            {
+                V8Value_SetBoolean(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetNumber(V8Value.Ptr pV8Value, double value)
+            {
+                V8Value_SetNumber(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetInt32(V8Value.Ptr pV8Value, int value)
+            {
+                V8Value_SetInt32(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetUInt32(V8Value.Ptr pV8Value, uint value)
+            {
+                V8Value_SetUInt32(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetString(V8Value.Ptr pV8Value, string value)
+            {
+                V8Value_SetString(pV8Value, value, value.Length);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetDateTime(V8Value.Ptr pV8Value, double value)
+            {
+                V8Value_SetDateTime(pV8Value, value);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetBigInt(V8Value.Ptr pV8Value, int signBit, byte[] bytes)
+            {
+                V8Value_SetBigInt(pV8Value, signBit, bytes, bytes.Length);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetV8Object(V8Value.Ptr pV8Value, V8Object.Handle hObject, V8Value.Subtype subtype)
+            {
+                V8Value_SetV8Object(pV8Value, hObject, subtype);
+            }
+
+            void IV8SplitProxyNative.V8Value_SetHostObject(V8Value.Ptr pV8Value, IntPtr pObject)
+            {
+                V8Value_SetHostObject(pV8Value, pObject);
+            }
+
+            V8Value.Type IV8SplitProxyNative.V8Value_Decode(V8Value.Ptr pV8Value, out int intValue, out uint uintValue, out double doubleValue, out IntPtr ptrOrHandle)
+            {
+                return V8Value_Decode(pV8Value, out intValue, out uintValue, out doubleValue, out ptrOrHandle);
+            }
+
+            void IV8SplitProxyNative.V8Value_Delete(V8Value.Ptr pV8Value)
+            {
+                V8Value_Delete(pV8Value);
+            }
+
+            #endregion
+
+            #region V8CpuProfile methods
+
+            void IV8SplitProxyNative.V8CpuProfile_GetInfo(V8CpuProfile.Ptr pProfile, V8Entity.Handle hEntity, out string name, out ulong startTimestamp, out ulong endTimestamp, out int sampleCount, out V8CpuProfile.Node.Ptr pRootNode)
+            {
+                using (var nameScope = StdString.CreateScope())
+                {
+                    V8CpuProfile_GetInfo(pProfile, hEntity, nameScope.Value, out startTimestamp, out endTimestamp, out sampleCount, out pRootNode);
+                    name = StdString.GetValue(nameScope.Value);
+                }
+            }
+
+            bool IV8SplitProxyNative.V8CpuProfile_GetSample(V8CpuProfile.Ptr pProfile, int index, out ulong nodeId, out ulong timestamp)
+            {
+                return V8CpuProfile_GetSample(pProfile, index, out nodeId, out timestamp);
+            }
+
+            void IV8SplitProxyNative.V8CpuProfileNode_GetInfo(V8CpuProfile.Node.Ptr pNode, V8Entity.Handle hEntity, out ulong nodeId, out long scriptId, out string scriptName, out string functionName, out string bailoutReason, out long lineNumber, out long columnNumber, out ulong hitCount, out uint hitLineCount, out int childCount)
+            {
+                using (var scriptNameScope = StdString.CreateScope())
+                {
+                    using (var functionNameScope = StdString.CreateScope())
+                    {
+                        using (var bailoutReasonScope = StdString.CreateScope())
+                        {
+                            V8CpuProfileNode_GetInfo(pNode, hEntity, out nodeId, out scriptId, scriptNameScope.Value, functionNameScope.Value, bailoutReasonScope.Value, out lineNumber, out columnNumber, out hitCount, out hitLineCount, out childCount);
+                            scriptName = StdString.GetValue(scriptNameScope.Value);
+                            functionName = StdString.GetValue(functionNameScope.Value);
+                            bailoutReason = StdString.GetValue(bailoutReasonScope.Value);
+
+                        }
+                    }
+                }
+            }
+
+            bool IV8SplitProxyNative.V8CpuProfileNode_GetHitLines(V8CpuProfile.Node.Ptr pNode, out int[] lineNumbers, out uint[] hitCounts)
+            {
+                using (var lineNumbersScope = StdInt32Array.CreateScope())
+                {
+                    using (var hitCountsScope = StdUInt32Array.CreateScope())
+                    {
+                        var result = V8CpuProfileNode_GetHitLines(pNode, lineNumbersScope.Value, hitCountsScope.Value);
+                        lineNumbers = StdInt32Array.ToArray(lineNumbersScope.Value);
+                        hitCounts = StdUInt32Array.ToArray(hitCountsScope.Value);
+                        return result;
+                    }
+                }
+            }
+
+            V8CpuProfile.Node.Ptr IV8SplitProxyNative.V8CpuProfileNode_GetChildNode(V8CpuProfile.Node.Ptr pNode, int index)
+            {
+                return V8CpuProfileNode_GetChildNode(pNode, index);
+            }
+
+            #endregion
+
+            #region V8 isolate methods
+
+            V8Isolate.Handle IV8SplitProxyNative.V8Isolate_Create(string name, int maxNewSpaceSize, int maxOldSpaceSize, double heapExpansionMultiplier, ulong maxArrayBufferAllocation, bool enableDebugging, bool enableRemoteDebugging, bool enableDynamicModuleImports, int debugPort)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Isolate_Create(nameScope.Value, maxNewSpaceSize, maxOldSpaceSize, heapExpansionMultiplier, maxArrayBufferAllocation, enableDebugging, enableRemoteDebugging, enableDynamicModuleImports, debugPort);
+                }
+            }
+
+            V8Context.Handle IV8SplitProxyNative.V8Isolate_CreateContext(V8Isolate.Handle hIsolate, string name, bool enableDebugging, bool enableRemoteDebugging, bool disableGlobalMembers, bool enableDateTimeConversion, bool enableDynamicModuleImports, int debugPort)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Isolate_CreateContext(hIsolate, nameScope.Value, enableDebugging, enableRemoteDebugging, disableGlobalMembers, enableDateTimeConversion, enableDynamicModuleImports, debugPort);
+                }
+            }
+
+            UIntPtr IV8SplitProxyNative.V8Isolate_GetMaxHeapSize(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetMaxHeapSize(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetMaxHeapSize(V8Isolate.Handle hIsolate, UIntPtr size)
+            {
+                V8Isolate_SetMaxHeapSize(hIsolate, size);
+            }
+
+            double IV8SplitProxyNative.V8Isolate_GetHeapSizeSampleInterval(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetHeapSizeSampleInterval(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetHeapSizeSampleInterval(V8Isolate.Handle hIsolate, double milliseconds)
+            {
+                V8Isolate_SetHeapSizeSampleInterval(hIsolate, milliseconds);
+            }
+
+            UIntPtr IV8SplitProxyNative.V8Isolate_GetMaxStackUsage(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetMaxStackUsage(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetMaxStackUsage(V8Isolate.Handle hIsolate, UIntPtr size)
+            {
+                V8Isolate_SetMaxStackUsage(hIsolate, size);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_AwaitDebuggerAndPause(V8Isolate.Handle hIsolate)
+            {
+                V8Isolate_AwaitDebuggerAndPause(hIsolate);
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Isolate_Compile(V8Isolate.Handle hIsolate, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            return V8Isolate_Compile(hIsolate, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value);
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Isolate_CompileProducingCache(V8Isolate.Handle hIsolate, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, out byte[] cacheBytes)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope())
+                            {
+                                var hScript = V8Isolate_CompileProducingCache(hIsolate, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value);
+                                cacheBytes = StdByteArray.ToArray(cacheBytesScope.Value);
+                                return hScript;
+                            }
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Isolate_CompileConsumingCache(V8Isolate.Handle hIsolate, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, byte[] cacheBytes, out bool cacheAccepted)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope(cacheBytes))
+                            {
+                                return V8Isolate_CompileConsumingCache(hIsolate, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value, out cacheAccepted);
+                            }
+                        }
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_GetHeapStatistics(V8Isolate.Handle hIsolate, out ulong totalHeapSize, out ulong totalHeapSizeExecutable, out ulong totalPhysicalSize, out ulong usedHeapSize, out ulong heapSizeLimit)
+            {
+                V8Isolate_GetHeapStatistics(hIsolate, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out usedHeapSize, out heapSizeLimit);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_GetStatistics(V8Isolate.Handle hIsolate, out ulong scriptCount, out ulong scriptCacheSize, out ulong moduleCount, out ulong[] postedTaskCounts, out ulong[] invokedTaskCounts)
+            {
+                using (var postedTaskCountsScope = StdUInt64Array.CreateScope())
+                {
+                    using (var invokedTaskCountsScope = StdUInt64Array.CreateScope())
+                    {
+                        V8Isolate_GetStatistics(hIsolate, out scriptCount, out scriptCacheSize, out moduleCount, postedTaskCountsScope.Value, invokedTaskCountsScope.Value);
+                        postedTaskCounts = StdUInt64Array.ToArray(postedTaskCountsScope.Value);
+                        invokedTaskCounts = StdUInt64Array.ToArray(invokedTaskCountsScope.Value);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_CollectGarbage(V8Isolate.Handle hIsolate, bool exhaustive)
+            {
+                V8Isolate_CollectGarbage(hIsolate, exhaustive);
+            }
+
+            bool IV8SplitProxyNative.V8Isolate_BeginCpuProfile(V8Isolate.Handle hIsolate, string name, bool recordSamples)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Isolate_BeginCpuProfile(hIsolate, nameScope.Value, recordSamples);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_EndCpuProfile(V8Isolate.Handle hIsolate, string name, IntPtr pAction)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    V8Isolate_EndCpuProfile(hIsolate, nameScope.Value, pAction);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Isolate_CollectCpuProfileSample(V8Isolate.Handle hIsolate)
+            {
+                V8Isolate_CollectCpuProfileSample(hIsolate);
+            }
+
+            uint IV8SplitProxyNative.V8Isolate_GetCpuProfileSampleInterval(V8Isolate.Handle hIsolate)
+            {
+                return V8Isolate_GetCpuProfileSampleInterval(hIsolate);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_SetCpuProfileSampleInterval(V8Isolate.Handle hIsolate, uint value)
+            {
+                V8Isolate_SetCpuProfileSampleInterval(hIsolate, value);
+            }
+
+            void IV8SplitProxyNative.V8Isolate_WriteHeapSnapshot(V8Isolate.Handle hIsolate, IntPtr pStream)
+            {
+                V8Isolate_WriteHeapSnapshot(hIsolate, pStream);
+            }
+
+            #endregion
+
+            #region V8 context methods
+
+            UIntPtr IV8SplitProxyNative.V8Context_GetMaxIsolateHeapSize(V8Context.Handle hContext)
+            {
+                return V8Context_GetMaxIsolateHeapSize(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetMaxIsolateHeapSize(V8Context.Handle hContext, UIntPtr size)
+            {
+                V8Context_SetMaxIsolateHeapSize(hContext, size);
+            }
+
+            double IV8SplitProxyNative.V8Context_GetIsolateHeapSizeSampleInterval(V8Context.Handle hContext)
+            {
+                return V8Context_GetIsolateHeapSizeSampleInterval(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetIsolateHeapSizeSampleInterval(V8Context.Handle hContext, double milliseconds)
+            {
+                V8Context_SetIsolateHeapSizeSampleInterval(hContext, milliseconds);
+            }
+
+            UIntPtr IV8SplitProxyNative.V8Context_GetMaxIsolateStackUsage(V8Context.Handle hContext)
+            {
+                return V8Context_GetMaxIsolateStackUsage(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetMaxIsolateStackUsage(V8Context.Handle hContext, UIntPtr size)
+            {
+                V8Context_SetMaxIsolateStackUsage(hContext, size);
+            }
+
+            void IV8SplitProxyNative.V8Context_InvokeWithLock(V8Context.Handle hContext, IntPtr pAction)
+            {
+                V8Context_InvokeWithLock(hContext, pAction);
+            }
+
+            object IV8SplitProxyNative.V8Context_GetRootItem(V8Context.Handle hContext)
+            {
+                using (var itemScope = V8Value.CreateScope())
+                {
+                    V8Context_GetRootItem(hContext, itemScope.Value);
+                    return V8Value.Get(itemScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_AddGlobalItem(V8Context.Handle hContext, string name, object value, bool globalMembers)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var valueScope = V8Value.CreateScope(value))
+                    {
+                        V8Context_AddGlobalItem(hContext, nameScope.Value, valueScope.Value, globalMembers);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_AwaitDebuggerAndPause(V8Context.Handle hContext)
+            {
+                V8Context_AwaitDebuggerAndPause(hContext);
+            }
+
+            object IV8SplitProxyNative.V8Context_ExecuteCode(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, bool evaluate)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var resultScope = V8Value.CreateScope())
+                            {
+                                V8Context_ExecuteCode(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, evaluate, resultScope.Value);
+                                return V8Value.Get(resultScope.Value);
+                            }
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Context_Compile(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            return V8Context_Compile(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value);
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Context_CompileProducingCache(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, out byte[] cacheBytes)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope())
+                            {
+                                var hScript = V8Context_CompileProducingCache(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value);
+                                cacheBytes = StdByteArray.ToArray(cacheBytesScope.Value);
+                                return hScript;
+                            }
+                        }
+                    }
+                }
+            }
+
+            V8Script.Handle IV8SplitProxyNative.V8Context_CompileConsumingCache(V8Context.Handle hContext, string resourceName, string sourceMapUrl, ulong uniqueId, bool isModule, IntPtr pDocumentInfo, string code, V8CacheKind cacheKind, byte[] cacheBytes, out bool cacheAccepted)
+            {
+                using (var resourceNameScope = StdString.CreateScope(resourceName))
+                {
+                    using (var sourceMapUrlScope = StdString.CreateScope(sourceMapUrl))
+                    {
+                        using (var codeScope = StdString.CreateScope(code))
+                        {
+                            using (var cacheBytesScope = StdByteArray.CreateScope(cacheBytes))
+                            {
+                                return V8Context_CompileConsumingCache(hContext, resourceNameScope.Value, sourceMapUrlScope.Value, uniqueId, isModule, pDocumentInfo, codeScope.Value, cacheKind, cacheBytesScope.Value, out cacheAccepted);
+                            }
+                        }
+                    }
+                }
+            }
+
+            object IV8SplitProxyNative.V8Context_ExecuteScript(V8Context.Handle hContext, V8Script.Handle hScript, bool evaluate)
+            {
+                using (var resultScope = V8Value.CreateScope())
+                {
+                    V8Context_ExecuteScript(hContext, hScript, evaluate, resultScope.Value);
+                    return V8Value.Get(resultScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_Interrupt(V8Context.Handle hContext)
+            {
+                V8Context_Interrupt(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_GetIsolateHeapStatistics(V8Context.Handle hContext, out ulong totalHeapSize, out ulong totalHeapSizeExecutable, out ulong totalPhysicalSize, out ulong usedHeapSize, out ulong heapSizeLimit)
+            {
+                V8Context_GetIsolateHeapStatistics(hContext, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out usedHeapSize, out heapSizeLimit);
+            }
+
+            void IV8SplitProxyNative.V8Context_GetIsolateStatistics(V8Context.Handle hContext, out ulong scriptCount, out ulong scriptCacheSize, out ulong moduleCount, out ulong[] postedTaskCounts, out ulong[] invokedTaskCounts)
+            {
+                using (var postedTaskCountsScope = StdUInt64Array.CreateScope())
+                {
+                    using (var invokedTaskCountsScope = StdUInt64Array.CreateScope())
+                    {
+                        V8Context_GetIsolateStatistics(hContext, out scriptCount, out scriptCacheSize, out moduleCount, postedTaskCountsScope.Value, invokedTaskCountsScope.Value);
+                        postedTaskCounts = StdUInt64Array.ToArray(postedTaskCountsScope.Value);
+                        invokedTaskCounts = StdUInt64Array.ToArray(invokedTaskCountsScope.Value);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_GetStatistics(V8Context.Handle hContext, out ulong scriptCount, out ulong moduleCount, out ulong moduleCacheSize)
+            {
+                V8Context_GetStatistics(hContext, out scriptCount, out moduleCount, out moduleCacheSize);
+            }
+
+            void IV8SplitProxyNative.V8Context_CollectGarbage(V8Context.Handle hContext, bool exhaustive)
+            {
+                V8Context_CollectGarbage(hContext, exhaustive);
+            }
+
+            void IV8SplitProxyNative.V8Context_OnAccessSettingsChanged(V8Context.Handle hContext)
+            {
+                V8Context_OnAccessSettingsChanged(hContext);
+            }
+
+            bool IV8SplitProxyNative.V8Context_BeginCpuProfile(V8Context.Handle hContext, string name, bool recordSamples)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Context_BeginCpuProfile(hContext, nameScope.Value, recordSamples);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_EndCpuProfile(V8Context.Handle hContext, string name, IntPtr pAction)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    V8Context_EndCpuProfile(hContext, nameScope.Value, pAction);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Context_CollectCpuProfileSample(V8Context.Handle hContext)
+            {
+                V8Context_CollectCpuProfileSample(hContext);
+            }
+
+            uint IV8SplitProxyNative.V8Context_GetCpuProfileSampleInterval(V8Context.Handle hContext)
+            {
+                return V8Context_GetCpuProfileSampleInterval(hContext);
+            }
+
+            void IV8SplitProxyNative.V8Context_SetCpuProfileSampleInterval(V8Context.Handle hContext, uint value)
+            {
+                V8Context_SetCpuProfileSampleInterval(hContext, value);
+            }
+
+            void IV8SplitProxyNative.V8Context_WriteIsolateHeapSnapshot(V8Context.Handle hContext, IntPtr pStream)
+            {
+                V8Context_WriteIsolateHeapSnapshot(hContext, pStream);
+            }
+
+            #endregion
+
+            #region V8 object methods
+
+            object IV8SplitProxyNative.V8Object_GetNamedProperty(V8Object.Handle hObject, string name)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var valueScope = V8Value.CreateScope())
+                    {
+                        V8Object_GetNamedProperty(hObject, nameScope.Value, valueScope.Value);
+                        return V8Value.Get(valueScope.Value);
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_SetNamedProperty(V8Object.Handle hObject, string name, object value)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var valueScope = V8Value.CreateScope(value))
+                    {
+                        V8Object_SetNamedProperty(hObject, nameScope.Value, valueScope.Value);
+                    }
+                }
+            }
+
+            bool IV8SplitProxyNative.V8Object_DeleteNamedProperty(V8Object.Handle hObject, string name)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    return V8Object_DeleteNamedProperty(hObject, nameScope.Value);
+                }
+            }
+
+            string[] IV8SplitProxyNative.V8Object_GetPropertyNames(V8Object.Handle hObject)
+            {
+                using (var namesScope = StdStringArray.CreateScope())
+                {
+                    V8Object_GetPropertyNames(hObject, namesScope.Value);
+                    return StdStringArray.ToArray(namesScope.Value);
+                }
+            }
+
+            object IV8SplitProxyNative.V8Object_GetIndexedProperty(V8Object.Handle hObject, int index)
+            {
+                using (var valueScope = V8Value.CreateScope())
+                {
+                    V8Object_GetIndexedProperty(hObject, index, valueScope.Value);
+                    return V8Value.Get(valueScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_SetIndexedProperty(V8Object.Handle hObject, int index, object value)
+            {
+                using (var valueScope = V8Value.CreateScope(value))
+                {
+                    V8Object_SetIndexedProperty(hObject, index, valueScope.Value);
+                }
+            }
+
+            bool IV8SplitProxyNative.V8Object_DeleteIndexedProperty(V8Object.Handle hObject, int index)
+            {
+                return V8Object_DeleteIndexedProperty(hObject, index);
+            }
+
+            int[] IV8SplitProxyNative.V8Object_GetPropertyIndices(V8Object.Handle hObject)
+            {
+                using (var indicesScope = StdInt32Array.CreateScope())
+                {
+                    V8Object_GetPropertyIndices(hObject, indicesScope.Value);
+                    return StdInt32Array.ToArray(indicesScope.Value);
+                }
+            }
+
+            object IV8SplitProxyNative.V8Object_Invoke(V8Object.Handle hObject, bool asConstructor, object[] args)
+            {
+                using (var argsScope = StdV8ValueArray.CreateScope(args))
+                {
+                    using (var resultScope = V8Value.CreateScope())
+                    {
+                        V8Object_Invoke(hObject, asConstructor, argsScope.Value, resultScope.Value);
+                        return V8Value.Get(resultScope.Value);
+                    }
+                }
+            }
+
+            object IV8SplitProxyNative.V8Object_InvokeMethod(V8Object.Handle hObject, string name, object[] args)
+            {
+                using (var nameScope = StdString.CreateScope(name))
+                {
+                    using (var argsScope = StdV8ValueArray.CreateScope(args))
+                    {
+                        using (var resultScope = V8Value.CreateScope())
+                        {
+                            V8Object_InvokeMethod(hObject, nameScope.Value, argsScope.Value, resultScope.Value);
+                            return V8Value.Get(resultScope.Value);
+                        }
+                    }
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_GetArrayBufferOrViewInfo(V8Object.Handle hObject, out IV8Object arrayBuffer, out ulong offset, out ulong size, out ulong length)
+            {
+                using (var arrayBufferScope = V8Value.CreateScope())
+                {
+                    V8Object_GetArrayBufferOrViewInfo(hObject, arrayBufferScope.Value, out offset, out size, out length);
+                    arrayBuffer = (IV8Object)V8Value.Get(arrayBufferScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8Object_InvokeWithArrayBufferOrViewData(V8Object.Handle hObject, IntPtr pAction)
+            {
+                V8Object_InvokeWithArrayBufferOrViewData(hObject, pAction);
+            }
+
+            #endregion
+
+            #region V8 debug callback methods
+
+            void IV8SplitProxyNative.V8DebugCallback_ConnectClient(V8DebugCallback.Handle hCallback)
+            {
+                V8DebugCallback_ConnectClient(hCallback);
+            }
+
+            void IV8SplitProxyNative.V8DebugCallback_SendCommand(V8DebugCallback.Handle hCallback, string command)
+            {
+                using (var commandScope = StdString.CreateScope(command))
+                {
+                    V8DebugCallback_SendCommand(hCallback, commandScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8DebugCallback_DisconnectClient(V8DebugCallback.Handle hCallback)
+            {
+                V8DebugCallback_DisconnectClient(hCallback);
+            }
+
+            #endregion
+
+            #region native callback methods
+
+            void IV8SplitProxyNative.NativeCallback_Invoke(NativeCallback.Handle hCallback)
+            {
+                NativeCallback_Invoke(hCallback);
+            }
+
+            #endregion
+
+            #region V8 entity cleanup
+
+            void IV8SplitProxyNative.V8Entity_Release(V8Entity.Handle hEntity)
+            {
+                V8Entity_Release(hEntity);
+            }
+
+            void IV8SplitProxyNative.V8Entity_DestroyHandle(V8Entity.Handle hEntity)
+            {
+                V8Entity_DestroyHandle(hEntity);
+            }
+
+            #endregion
+
+            #region error handling
+
+            void IV8SplitProxyNative.HostException_Schedule(string message, object exception)
+            {
+                using (var messageScope = StdString.CreateScope(message))
+                {
+                    using (var exceptionScope = V8Value.CreateScope(exception))
+                    {
+                        HostException_Schedule(messageScope.Value, exceptionScope.Value);
+                    }
+                }
+            }
+
+            #endregion
+
+            #region unit test support
+
+            UIntPtr IV8SplitProxyNative.V8UnitTestSupport_GetTextDigest(string value)
+            {
+                using (var valueScope = StdString.CreateScope(value))
+                {
+                    return V8UnitTestSupport_GetTextDigest(valueScope.Value);
+                }
+            }
+
+            void IV8SplitProxyNative.V8UnitTestSupport_GetStatistics(out ulong isolateCount, out ulong contextCount)
+            {
+                V8UnitTestSupport_GetStatistics(out isolateCount, out contextCount);
+            }
+
+            #endregion
+
+            #endregion
+
+            #region native methods
+
+            #region initialization
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr V8SplitProxyManaged_SetMethodTable(
+                [In] IntPtr pMethodTable
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Environment_InitializeICU(
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string dataPath
+            );
+
+            #endregion
+
+            #region StdString methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdString.Ptr StdString_New(
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdString_GetValue(
+                [In] StdString.Ptr pString,
+                [Out] out int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdString_SetValue(
+                [In] StdString.Ptr pString,
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdString_Delete(
+                [In] StdString.Ptr pString
+            );
+
+            #endregion
+
+            #region StdStringArray methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdStringArray.Ptr StdStringArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdStringArray_GetElementCount(
+                [In] StdStringArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdStringArray_SetElementCount(
+                [In] StdStringArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdStringArray_GetElement(
+                [In] StdStringArray.Ptr pArray,
+                [In] int index,
+                [Out] out int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdStringArray_SetElement(
+                [In] StdStringArray.Ptr pArray,
+                [In] int index,
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdStringArray_Delete(
+                [In] StdStringArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdByteArray methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdByteArray.Ptr StdByteArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdByteArray_GetElementCount(
+                [In] StdByteArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdByteArray_SetElementCount(
+                [In] StdByteArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdByteArray_GetData(
+                [In] StdByteArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdByteArray_Delete(
+                [In] StdByteArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdInt32Array methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdInt32Array.Ptr StdInt32Array_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdInt32Array_GetElementCount(
+                [In] StdInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdInt32Array_SetElementCount(
+                [In] StdInt32Array.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdInt32Array_GetData(
+                [In] StdInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdInt32Array_Delete(
+                [In] StdInt32Array.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdUInt32Array methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdUInt32Array.Ptr StdUInt32Array_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdUInt32Array_GetElementCount(
+                [In] StdUInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt32Array_SetElementCount(
+                [In] StdUInt32Array.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdUInt32Array_GetData(
+                [In] StdUInt32Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt32Array_Delete(
+                [In] StdUInt32Array.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdUInt64Array methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdUInt64Array.Ptr StdUInt64Array_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdUInt64Array_GetElementCount(
+                [In] StdUInt64Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt64Array_SetElementCount(
+                [In] StdUInt64Array.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdUInt64Array_GetData(
+                [In] StdUInt64Array.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdUInt64Array_Delete(
+                [In] StdUInt64Array.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdPtrArray methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdPtrArray.Ptr StdPtrArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdPtrArray_GetElementCount(
+                [In] StdPtrArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdPtrArray_SetElementCount(
+                [In] StdPtrArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern IntPtr StdPtrArray_GetData(
+                [In] StdPtrArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdPtrArray_Delete(
+                [In] StdPtrArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region StdV8ValueArray methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern StdV8ValueArray.Ptr StdV8ValueArray_New(
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern int StdV8ValueArray_GetElementCount(
+                [In] StdV8ValueArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdV8ValueArray_SetElementCount(
+                [In] StdV8ValueArray.Ptr pArray,
+                [In] int elementCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Value.Ptr StdV8ValueArray_GetData(
+                [In] StdV8ValueArray.Ptr pArray
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void StdV8ValueArray_Delete(
+                [In] StdV8ValueArray.Ptr pArray
+            );
+
+            #endregion
+
+            #region V8Value methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Value.Ptr V8Value_New();
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetNonexistent(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetUndefined(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetNull(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetBoolean(
+                [In] V8Value.Ptr pV8Value,
+                [In] [MarshalAs(UnmanagedType.I1)] bool value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetNumber(
+                [In] V8Value.Ptr pV8Value,
+                [In] double value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetInt32(
+                [In] V8Value.Ptr pV8Value,
+                [In] int value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetUInt32(
+                [In] V8Value.Ptr pV8Value,
+                [In] uint value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetString(
+                [In] V8Value.Ptr pV8Value,
+                [In] [MarshalAs(UnmanagedType.LPWStr)] string value,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetDateTime(
+                [In] V8Value.Ptr pV8Value,
+                [In] double value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetBigInt(
+                [In] V8Value.Ptr pV8Value,
+                [In] int signBit,
+                [In] [MarshalAs(UnmanagedType.LPArray)] byte[] bytes,
+                [In] int length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetV8Object(
+                [In] V8Value.Ptr pV8Value,
+                [In] V8Object.Handle hObject,
+                [In] V8Value.Subtype subtype
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_SetHostObject(
+                [In] V8Value.Ptr pV8Value,
+                [In] IntPtr pObject
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Value.Type V8Value_Decode(
+                [In] V8Value.Ptr pV8Value,
+                [Out] out int intValue,
+                [Out] out uint uintValue,
+                [Out] out double doubleValue,
+                [Out] out IntPtr ptrOrHandle
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Value_Delete(
+                [In] V8Value.Ptr pV8Value
+            );
+
+            #endregion
+
+            #region V8CpuProfile methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8CpuProfile_GetInfo(
+                [In] V8CpuProfile.Ptr pProfile,
+                [In] V8Entity.Handle hEntity,
+                [In] StdString.Ptr pName,
+                [Out] out ulong startTimestamp,
+                [Out] out ulong endTimestamp,
+                [Out] out int sampleCount,
+                [Out] out V8CpuProfile.Node.Ptr pRootNode
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8CpuProfile_GetSample(
+                [In] V8CpuProfile.Ptr pProfile,
+                [In] int index,
+                [Out] out ulong nodeId,
+                [Out] out ulong timestamp
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8CpuProfileNode_GetInfo(
+                [In] V8CpuProfile.Node.Ptr pNode,
+                [In] V8Entity.Handle hEntity,
+                [Out] out ulong nodeId,
+                [Out] out long scriptId,
+                [In] StdString.Ptr pScriptName,
+                [In] StdString.Ptr pFunctionName,
+                [In] StdString.Ptr pBailoutReason,
+                [Out] out long lineNumber,
+                [Out] out long columnNumber,
+                [Out] out ulong hitCount,
+                [Out] out uint hitLineCount,
+                [Out] out int childCount
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8CpuProfileNode_GetHitLines(
+                [In] V8CpuProfile.Node.Ptr pNode,
+                [In] StdInt32Array.Ptr pLineNumbers,
+                [In] StdUInt32Array.Ptr pHitCounts
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8CpuProfile.Node.Ptr V8CpuProfileNode_GetChildNode(
+                [In] V8CpuProfile.Node.Ptr pNode,
+                [In] int index
+            );
+
+            #endregion
+
+            #region V8 isolate methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Isolate.Handle V8Isolate_Create(
+                [In] StdString.Ptr pName,
+                [In] int maxNewSpaceSize,
+                [In] int maxOldSpaceSize,
+                [In] double heapExpansionMultiplier,
+                [In] ulong maxArrayBufferAllocation,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableRemoteDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDynamicModuleImports,
+                [In] int debugPort
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Context.Handle V8Isolate_CreateContext(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pName,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableRemoteDebugging,
+                [In] [MarshalAs(UnmanagedType.I1)] bool disableGlobalMembers,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDateTimeConversion,
+                [In] [MarshalAs(UnmanagedType.I1)] bool enableDynamicModuleImports,
+                [In] int debugPort
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Isolate_GetMaxHeapSize(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetMaxHeapSize(
+                [In] V8Isolate.Handle hIsolate,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern double V8Isolate_GetHeapSizeSampleInterval(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetHeapSizeSampleInterval(
+                [In] V8Isolate.Handle hIsolate,
+                [In] double milliseconds
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Isolate_GetMaxStackUsage(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetMaxStackUsage(
+                [In] V8Isolate.Handle hIsolate,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_AwaitDebuggerAndPause(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Isolate_Compile(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Isolate_CompileProducingCache(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Isolate_CompileConsumingCache(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes,
+                [Out] [MarshalAs(UnmanagedType.I1)] out bool cacheAccepted
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_GetHeapStatistics(
+                [In] V8Isolate.Handle hIsolate,
+                [Out] out ulong totalHeapSize,
+                [Out] out ulong totalHeapSizeExecutable,
+                [Out] out ulong totalPhysicalSize,
+                [Out] out ulong usedHeapSize,
+                [Out] out ulong heapSizeLimit
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_GetStatistics(
+                [In] V8Isolate.Handle hIsolate,
+                [Out] out ulong scriptCount,
+                [Out] out ulong scriptCacheSize,
+                [Out] out ulong moduleCount,
+                [In] StdUInt64Array.Ptr pPostedTaskCounts,
+                [In] StdUInt64Array.Ptr pInvokedTaskCounts
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_CollectGarbage(
+                [In] V8Isolate.Handle hIsolate,
+                [In] [MarshalAs(UnmanagedType.I1)] bool exhaustive
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Isolate_BeginCpuProfile(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pName,
+                [In] [MarshalAs(UnmanagedType.I1)] bool recordSamples
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_EndCpuProfile(
+                [In] V8Isolate.Handle hIsolate,
+                [In] StdString.Ptr pName,
+                [In] IntPtr pAction
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_CollectCpuProfileSample(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern uint V8Isolate_GetCpuProfileSampleInterval(
+                [In] V8Isolate.Handle hIsolate
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_SetCpuProfileSampleInterval(
+                [In] V8Isolate.Handle hIsolate,
+                [In] uint value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Isolate_WriteHeapSnapshot(
+                [In] V8Isolate.Handle hIsolate,
+                [In] IntPtr pStream
+            );
+
+            #endregion
+
+            #region V8 context methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Context_GetMaxIsolateHeapSize(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetMaxIsolateHeapSize(
+                [In] V8Context.Handle hContext,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern double V8Context_GetIsolateHeapSizeSampleInterval(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetIsolateHeapSizeSampleInterval(
+                [In] V8Context.Handle hContext,
+                [In] double milliseconds
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8Context_GetMaxIsolateStackUsage(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetMaxIsolateStackUsage(
+                [In] V8Context.Handle hContext,
+                [In] UIntPtr size
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_InvokeWithLock(
+                [In] V8Context.Handle hContext,
+                [In] IntPtr pAction
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetRootItem(
+                [In] V8Context.Handle hContext,
+                [In] V8Value.Ptr pItem
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_AddGlobalItem(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pName,
+                [In] V8Value.Ptr pValue,
+                [In] [MarshalAs(UnmanagedType.I1)] bool globalMembers
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_AwaitDebuggerAndPause(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_ExecuteCode(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] [MarshalAs(UnmanagedType.I1)] bool evaluate,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Context_Compile(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Context_CompileProducingCache(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern V8Script.Handle V8Context_CompileConsumingCache(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pResourceName,
+                [In] StdString.Ptr pSourceMapUrl,
+                [In] ulong uniqueId,
+                [In] [MarshalAs(UnmanagedType.I1)] bool isModule,
+                [In] IntPtr pDocumentInfo,
+                [In] StdString.Ptr pCode,
+                [In] V8CacheKind cacheKind,
+                [In] StdByteArray.Ptr pCacheBytes,
+                [Out] [MarshalAs(UnmanagedType.I1)] out bool cacheAccepted
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_ExecuteScript(
+                [In] V8Context.Handle hContext,
+                [In] V8Script.Handle hScript,
+                [In] [MarshalAs(UnmanagedType.I1)] bool evaluate,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_Interrupt(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetIsolateHeapStatistics(
+                [In] V8Context.Handle hContext,
+                [Out] out ulong totalHeapSize,
+                [Out] out ulong totalHeapSizeExecutable,
+                [Out] out ulong totalPhysicalSize,
+                [Out] out ulong usedHeapSize,
+                [Out] out ulong heapSizeLimit
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetIsolateStatistics(
+                [In] V8Context.Handle hContext,
+                [Out] out ulong scriptCount,
+                [Out] out ulong scriptCacheSize,
+                [Out] out ulong moduleCount,
+                [In] StdUInt64Array.Ptr pPostedTaskCounts,
+                [In] StdUInt64Array.Ptr pInvokedTaskCounts
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_GetStatistics(
+                [In] V8Context.Handle hContext,
+                [Out] out ulong scriptCount,
+                [Out] out ulong moduleCount,
+                [Out] out ulong moduleCacheSize
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_CollectGarbage(
+                [In] V8Context.Handle hContext,
+                [In] [MarshalAs(UnmanagedType.I1)] bool exhaustive
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_OnAccessSettingsChanged(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Context_BeginCpuProfile(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pName,
+                [In] [MarshalAs(UnmanagedType.I1)] bool recordSamples
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_EndCpuProfile(
+                [In] V8Context.Handle hContext,
+                [In] StdString.Ptr pName,
+                [In] IntPtr pAction
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_CollectCpuProfileSample(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern uint V8Context_GetCpuProfileSampleInterval(
+                [In] V8Context.Handle hContext
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_SetCpuProfileSampleInterval(
+                [In] V8Context.Handle hContext,
+                [In] uint value
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Context_WriteIsolateHeapSnapshot(
+                [In] V8Context.Handle hContext,
+                [In] IntPtr pStream
+            );
+
+            #endregion
+
+            #region V8 object methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetNamedProperty(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_SetNamedProperty(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Object_DeleteNamedProperty(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetPropertyNames(
+                [In] V8Object.Handle hObject,
+                [In] StdStringArray.Ptr pNames
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetIndexedProperty(
+                [In] V8Object.Handle hObject,
+                [In] int index,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_SetIndexedProperty(
+                [In] V8Object.Handle hObject,
+                [In] int index,
+                [In] V8Value.Ptr pValue
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            [return: MarshalAs(UnmanagedType.I1)]
+            private static extern bool V8Object_DeleteIndexedProperty(
+                [In] V8Object.Handle hObject,
+                [In] int index
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetPropertyIndices(
+                [In] V8Object.Handle hObject,
+                [In] StdInt32Array.Ptr pIndices
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_Invoke(
+                [In] V8Object.Handle hObject,
+                [In] [MarshalAs(UnmanagedType.I1)] bool asConstructor,
+                [In] StdV8ValueArray.Ptr pArgs,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_InvokeMethod(
+                [In] V8Object.Handle hObject,
+                [In] StdString.Ptr pName,
+                [In] StdV8ValueArray.Ptr pArgs,
+                [In] V8Value.Ptr pResult
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_GetArrayBufferOrViewInfo(
+                [In] V8Object.Handle hObject,
+                [In] V8Value.Ptr pArrayBuffer,
+                [Out] out ulong offset,
+                [Out] out ulong size,
+                [Out] out ulong length
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Object_InvokeWithArrayBufferOrViewData(
+                [In] V8Object.Handle hObject,
+                [In] IntPtr pAction
+            );
+
+            #endregion
+
+            #region V8 debug callback methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8DebugCallback_ConnectClient(
+                [In] V8DebugCallback.Handle hCallback
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8DebugCallback_SendCommand(
+                [In] V8DebugCallback.Handle hCallback,
+                [In] StdString.Ptr pCommand
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8DebugCallback_DisconnectClient(
+                [In] V8DebugCallback.Handle hCallback
+            );
+
+            #endregion
+
+            #region native callback methods
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void NativeCallback_Invoke(
+                [In] NativeCallback.Handle hCallback
+            );
+
+            #endregion
+
+            #region V8 entity cleanup
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Entity_Release(
+                [In] V8Entity.Handle hEntity
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8Entity_DestroyHandle(
+                [In] V8Entity.Handle hEntity
+            );
+
+            #endregion
+
+            #region error handling
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void HostException_Schedule(
+                [In] StdString.Ptr pMessage,
+                [In] V8Value.Ptr pException
+            );
+
+            #endregion
+
+            #region unit test support
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern UIntPtr V8UnitTestSupport_GetTextDigest(
+                [In] StdString.Ptr pString
+            );
+
+            [DllImport("ClearScriptV8.android-arm.so", CallingConvention = CallingConvention.StdCall)]
+            private static extern void V8UnitTestSupport_GetStatistics(
+                [Out] out ulong isolateCount,
+                [Out] out ulong contextCount
+            );
+
+            #endregion
+
+            #endregion
+        }
+
+        #endregion
+
+        
+
         #region Nested type: Impl_Windows_Arm64
 
         private sealed class Impl_Windows_Arm64 : IV8SplitProxyNative
@@ -5819,6 +9683,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Linux_X64
 
         private sealed class Impl_Linux_X64 : IV8SplitProxyNative
@@ -7728,6 +11593,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Linux_Arm64
 
         private sealed class Impl_Linux_Arm64 : IV8SplitProxyNative
@@ -9637,6 +13503,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_Linux_Arm
 
         private sealed class Impl_Linux_Arm : IV8SplitProxyNative
@@ -11546,6 +15413,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_OSX_X64
 
         private sealed class Impl_OSX_X64 : IV8SplitProxyNative
@@ -13455,6 +17323,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
         #region Nested type: Impl_OSX_Arm64
 
         private sealed class Impl_OSX_Arm64 : IV8SplitProxyNative
@@ -15364,6 +19233,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         #endregion
 
         
+
     }
 }
 

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT license.
 
 using System;
+using System.Runtime.InteropServices;
 using Microsoft.ClearScript.Util;
 
 namespace Microsoft.ClearScript.V8.SplitProxy
@@ -74,6 +75,76 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             if (V8SplitProxyManaged.ScheduledException != null)
             {
                 throw V8SplitProxyManaged.ScheduledException;
+            }
+        }
+
+        private static bool IsOSPlatform(string os)
+        {
+            if (os == "Android")
+            {
+                return HostSettings.IsAndroid;
+            }
+
+            if (os == "Windows")
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+            }
+
+            if (os == "Linux")
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
+            }
+
+            if (os == "OSX")
+            {
+                return RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+            }
+
+            return false;
+        }
+
+
+        private static bool IsArchitecture(string os, string arch)
+        {
+            var architecture = RuntimeInformation.ProcessArchitecture;
+
+            if (os == "Android")
+            {
+                if (arch == "X86" || arch == "Arm")
+                {
+                    return architecture == Architecture.X86 || architecture == Architecture.Arm;
+                }
+                else if (arch == "X64" || arch == "Arm64")
+                {
+                    return architecture == Architecture.X64 || architecture == Architecture.Arm64;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+            else
+            {
+                if (arch == "X86")
+                {
+                    return architecture == Architecture.X86;
+                }
+                else if (arch == "X64")
+                {
+                    return architecture == Architecture.X64;
+                }
+                else if (arch == "Arm")
+                {
+                    return architecture == Architecture.Arm;
+                }
+                else if (arch == "Arm64")
+                {
+                    return architecture == Architecture.Arm64;
+                }
+                else
+                {
+                    return false;
+                }
             }
         }
     }

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.tt
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.tt
@@ -12,6 +12,8 @@
 {
     ("Windows", "X86", "win-x86.dll"),
     ("Windows", "X64", "win-x64.dll"),
+    ("Android", "Arm64", "android-arm64.so"),
+    ("Android", "Arm", "android-arm.so"),
     ("Windows", "Arm64", "win-arm64.dll"),
     ("Linux", "X64", "linux-x64.so"),
     ("Linux", "Arm64", "linux-arm64.so"),

--- a/Unix/ClearScriptV8/Makefile
+++ b/Unix/ClearScriptV8/Makefile
@@ -7,6 +7,12 @@ else
 endif
 
 KERNEL = $(shell uname -s)
+
+TARGETSUFFIX = gnu
+TARGETARCHSUFFIX =
+TARGETSUFFIXVER =
+UPDATEFLAGS =
+
 ifeq ($(KERNEL), Darwin)
     OS = osx
     EXTENSION = dylib
@@ -15,6 +21,9 @@ ifeq ($(KERNEL), Darwin)
     TARGETARCH_X64 = x86_64
     TARGETARCH_ARM = arm
     TARGETARCH_ARM64 = arm64
+    ifdef ANDROID
+        $(error Linux is required to build android)
+    endif
 else ifeq ($(KERNEL), Linux)
     OS = linux
     EXTENSION = so
@@ -23,6 +32,17 @@ else ifeq ($(KERNEL), Linux)
     TARGETARCH_X64 = x86_64
     TARGETARCH_ARM = arm
     TARGETARCH_ARM64 = aarch64
+    
+    ifdef ANDROID
+        OS = android
+        TARGETARCH_X86 = i686
+        TARGETARCH_X64 = x86_64
+        TARGETARCH_ARM = arm
+        TARGETARCH_ARM64 = aarch64
+        TARGETSUFFIX = android
+        TARGETSUFFIXVER = 21
+        UPDATEFLAGS = -a
+    endif
 else
     $(error unsupported operating system '$(KERNEL)')
 endif
@@ -56,32 +76,17 @@ else ifeq ($(CPU), x64)
     TARGETARCH = $(TARGETARCH_X64)
 else ifeq ($(CPU), arm)
     TARGETARCH = $(TARGETARCH_ARM)
-    TARGETSUFFIX = eabihf
+    TARGETSUFFIX = gnueabihf
+    ifdef ANDROID
+        TARGETARCHSUFFIX = v7a
+        TARGETSUFFIX = androideabi
+    endif
 else ifeq ($(CPU), arm64)
     TARGETARCH = $(TARGETARCH_ARM64)
 else
     $(error unsupported target CPU '$(CPU)')
 endif
 
-STRIP = true
-ifeq ($(TARGETOS), linux)
-    TARGET = $(TARGETARCH)-$(TARGETOS)-gnu$(TARGETSUFFIX)
-    ifndef DEBUG
-        CXXLINKFLAGS := -s
-    endif
-    CXXLINKFLAGS := $(CXXLINKFLAGS) -static-libstdc++ -static-libgcc
-    ifneq ($(HOSTCPU), $(CPU))
-        CXXCROSSFLAGS = -I/usr/$(TARGET)/include
-        CXXLINKFLAGS := -fuse-ld=/usr/$(TARGET)/bin/ld $(CXXLINKFLAGS)
-    endif
-else ifeq ($(TARGETOS), darwin)
-    TARGET = $(TARGETARCH)-$(TARGETOS)
-    ifndef DEBUG
-        STRIP = strip -r -u
-    endif
-else
-    $(error unsupported target operating system '$(TARGETOS)')
-endif
 
 MAKEFILE = $(word $(words $(MAKEFILE_LIST)), $(MAKEFILE_LIST))
 MAKEDIR = $(dir $(abspath $(MAKEFILE)))
@@ -94,13 +99,45 @@ V8BUILDDIR = $(V8ROOTDIR)/build
 V8DIR = $(V8BUILDDIR)/v8
 V8INCDIR = $(V8DIR)/include
 V8OUTDIR = $(V8DIR)/out/$(CPU)/$(CONFIG)
+
+ifdef ANDROID
+    V8OUTDIR = $(V8DIR)/out/android_$(CPU)/$(CONFIG)
+endif
+
 V8LIBDIR = $(V8OUTDIR)/obj
+CXX = clang++
+
+NDK = $(V8DIR)/third_party/android_ndk
+LLVM = $(NDK)/toolchains/llvm/prebuilt/$(TARGETOS)-$(ARCH)
+TOOLS = $(TARGETARCH)-$(TARGETOS)-$(TARGETSUFFIX)
+
+STRIP = true
+ifeq ($(TARGETOS), linux)
+    TARGET = $(TARGETARCH)$(TARGETARCHSUFFIX)-$(TARGETOS)-$(TARGETSUFFIX)$(TARGETSUFFIXVER)
+    ifndef DEBUG
+        CXXLINKFLAGS := -s
+    endif
+    CXXLINKFLAGS := $(CXXLINKFLAGS) -static-libstdc++ -static-libgcc
+    ifdef ANDROID
+        CXXLINKFLAGS := -fuse-ld=$(LLVM)/$(TOOLS)/bin/ld $(CXXLINKFLAGS)
+        CXX = $(LLVM)/bin/$(TARGET)-clang++
+    else ifneq ($(HOSTCPU), $(CPU))
+        CXXCROSSFLAGS = -I/usr/$(TARGET)/include
+        CXXLINKFLAGS := -fuse-ld=/usr/$(TARGET)/bin/ld $(CXXLINKFLAGS)
+    endif
+else ifeq ($(TARGETOS), darwin)
+    TARGET = $(TARGETARCH)-$(TARGETOS)
+    ifndef DEBUG
+        STRIP = strip -r -u
+    endif
+else
+    $(error unsupported target operating system '$(TARGETOS)')
+endif
 
 OUTDIR = $(ROOTDIR)/bin/$(CONFIG)/Unix
 OBJDIR = $(OUTDIR)/obj/$(CPU)
 CLEARSCRIPTV8 = $(OUTDIR)/ClearScriptV8.$(OS)-$(CPU).$(EXTENSION)
 
-CXX = clang++
 CXXFLAGS = --target=$(TARGET) -std=c++17 -fvisibility=default -fPIC -fno-rtti -Wno-ignored-attributes $(CXXCONFIGFLAGS) -I$(V8INCDIR) $(CXXCROSSFLAGS)
 
 HEADERS = $(wildcard $(SRCDIR)/*.h)
@@ -135,13 +172,13 @@ $(OBJDIR)/%.o: $(SRCDIR)/%.cpp $(HEADERS)
 	$(CXX) $(CXXFLAGS) -c $< -o $@
 
 $(V8LIBDIR)/libv8_monolith.a:
-	cd $(UNIXDIR); ./V8Update.sh -n -y $(CPU) $(CONFIG)
+	cd $(UNIXDIR); ./V8Update.sh -n -y $(UPDATEFLAGS) $(CPU) $(CONFIG)
 
 clean:
 	rm -rf $(CLEARSCRIPTV8) $(OBJDIR)
 
 buildv8:
-	cd $(UNIXDIR); ./V8Update.sh -n -y $(CPU) $(CONFIG)
+	cd $(UNIXDIR); ./V8Update.sh -n -y $(UPDATEFLAGS) $(CPU) $(CONFIG)
 
 cleanv8:
 	rm -rf $(V8OUTDIR)


### PR DESCRIPTION
This PR partially adds support for using V8 with ClearScript in Android Mono. It is partial because it requires some manual steps, and it uses some solutions which can be considered as _hacks_.

The PR may not be up to merging standards but I opened it hoping that I can get some feedback or other people may find it useful.

Summary of what was done:
- Adds `-a` flag to `V8Update.sh`, and `ANDROID` symbol to Makefile to build V8 for Android. It can build for `arm` and `arm64` architectures and can only be built in Linux. To be able to build, it is required to install `build-dependencies.sh` of v8 as far as I can tell.
  - This builds `ClearScriptV8.android-arm.so` and `ClearScriptV8.android-arm64.so` but they need to be prefixed with `lib` like `libClearScriptV8.android-arm.so` otherwise they won't work in Android when built with release configuration for some reason (works with debug though, I guess it is a Mono bug). 
- Added `HostSettings.IsAndroid` to tell the ClearScript that current platform is Android. The user must set this setting to true in Android platforms. (For example, I am using `#if UNITY_ANDROID` build flag to conditionally add it)
  - This is because .NET (and Mono) cannot differentiate between Android and Linux so I had to add this setting. Likewise it incorrectly reports `Arm` as `X86` so I had to add some hacks for that.
- Added interfaces to Android native libraries. They were similar to Linux so it was fairly easy.
