### PR TITLE
Free GC handles after unloading library

### DIFF
--- a/ClearScript/V8/V8Proxy.cs
+++ b/ClearScript/V8/V8Proxy.cs
@@ -31,7 +31,7 @@ namespace Microsoft.ClearScript.V8
                 {
                     triedToLoadNativeAssembly = true;
                     var initializedICU = false;
-
+                    V8SplitProxyManaged.Initialize();
                     try
                     {
                         hNativeAssembly = LoadNativeAssembly();
@@ -66,6 +66,7 @@ namespace Microsoft.ClearScript.V8
                     FreeLibrary(hNativeAssembly);
                     hNativeAssembly = IntPtr.Zero;
                     loadedNativeAssembly = false;
+                    V8SplitProxyManaged.TearDown();
                 }
             }
         }


### PR DESCRIPTION
As per: https://github.com/microsoft/ClearScript/discussions/394

I've tested this manually and it seems to do the right thing.
I guess having an automated test for this might be quite finicky given it relies on a multi-project setup.