### PR TITLE
Make a `MemberComparer` class more reliable

### DIFF
--- a/ClearScript/Util/MemberComparer.cs
+++ b/ClearScript/Util/MemberComparer.cs
@@ -16,6 +16,15 @@ namespace Microsoft.ClearScript.Util
 
         public override bool Equals(T x, T y)
         {
+            if ((x == null) && (y == null))
+            {
+                return true;
+            }
+            else if ((x == null) || (y == null))
+            {
+                return false;
+            }
+
             try
             {
                 return (x.Module == y.Module) && (x.MetadataToken == y.MetadataToken);


### PR DESCRIPTION
Current implementation of the `MemberComparer` class uses a `try-catch` block to suppress exceptions. I think it's worth changing the implementation to a more standard one.