### PR TITLE
Don't depend on vulnerable versions of packages

### DIFF
--- a/NetCore/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetCore/ClearScript.V8/ClearScript.V8.csproj
@@ -144,7 +144,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetCore/ClearScriptConsole/ClearScriptConsole.csproj
+++ b/NetCore/ClearScriptConsole/ClearScriptConsole.csproj
@@ -40,7 +40,7 @@
 
     <ItemGroup>
         <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetCore/ClearScriptTest/ClearScriptTest.csproj
+++ b/NetCore/ClearScriptTest/ClearScriptTest.csproj
@@ -136,6 +136,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.4.0" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetFramework/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetFramework/ClearScript.V8/ClearScript.V8.csproj
@@ -175,7 +175,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetFramework/ClearScriptConsole/ClearScriptConsole.csproj
+++ b/NetFramework/ClearScriptConsole/ClearScriptConsole.csproj
@@ -44,7 +44,7 @@
 
     <ItemGroup>
         <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetFramework/ClearScriptTest/ClearScriptTest.csproj
+++ b/NetFramework/ClearScriptTest/ClearScriptTest.csproj
@@ -126,7 +126,8 @@
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetStandard/ClearScript.V8.ICUData/ClearScript.V8.ICUData.csproj
+++ b/NetStandard/ClearScript.V8.ICUData/ClearScript.V8.ICUData.csproj
@@ -52,7 +52,8 @@
     </ItemGroup>
 
     <ItemGroup>
-      <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+        <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
 </Project>

--- a/NetStandard/ClearScript.V8/ClearScript.V8.csproj
+++ b/NetStandard/ClearScript.V8/ClearScript.V8.csproj
@@ -141,7 +141,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetStandard/ClearScriptConsole/ClearScriptConsole.csproj
+++ b/NetStandard/ClearScriptConsole/ClearScriptConsole.csproj
@@ -42,7 +42,8 @@
 
     <ItemGroup>
         <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/NetStandard/ClearScriptTest.NetStandard/ClearScriptTest.NetStandard.csproj
+++ b/NetStandard/ClearScriptTest.NetStandard/ClearScriptTest.NetStandard.csproj
@@ -141,6 +141,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.4.0" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Unix/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
+++ b/Unix/ClearScriptBenchmarks/ClearScriptBenchmarks.csproj
@@ -43,6 +43,7 @@
     <ItemGroup>
         <ProjectReference Include="..\..\NetCore\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\..\NetCore\ClearScript.V8\ClearScript.V8.csproj" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
 </Project>

--- a/Unix/ClearScriptConsole/ClearScriptConsole.csproj
+++ b/Unix/ClearScriptConsole/ClearScriptConsole.csproj
@@ -46,7 +46,8 @@
 
     <ItemGroup>
         <PackageReference Include="MSTest.TestFramework" Version="3.0.2" />
-        <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
+        <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Unix/ClearScriptTest.NetStandard/ClearScriptTest.NetStandard.csproj
+++ b/Unix/ClearScriptTest.NetStandard/ClearScriptTest.NetStandard.csproj
@@ -114,6 +114,7 @@
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
         <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Version="4.4.0" />
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Unix/ClearScriptTest/ClearScriptTest.csproj
+++ b/Unix/ClearScriptTest/ClearScriptTest.csproj
@@ -260,6 +260,7 @@
         <ProjectReference Include="..\..\NetCore\ClearScript.Core\ClearScript.Core.csproj" />
         <ProjectReference Include="..\..\NetCore\ClearScript.Windows.Core\ClearScript.Windows.Core.csproj" />
         <ProjectReference Include="..\..\NetCore\ClearScript.V8\ClearScript.V8.csproj" />
+        <PackageReference Include="System.Text.RegularExpressions" Version="4.3.1" />
     </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This change adds direct dependencies to non-vulnerable versions of packages. Because warnings as errors is on, the solution cannot be built without this change.