### PR TITLE
Sketch of an interface that bypasses the HostObject code

### DIFF
--- a/ClearScript/V8/IV8HostObject.cs
+++ b/ClearScript/V8/IV8HostObject.cs
@@ -1,0 +1,141 @@
+using System;
+using Microsoft.ClearScript.V8.SplitProxy;
+
+namespace Microsoft.ClearScript.V8.Unsafe
+{
+    /// <summary>
+    /// 
+    /// </summary>
+    public interface IV8HostObject
+    {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        /// <param name="isConst"></param>
+        void GetNamedProperty(StdString name, V8Value value, out bool isConst);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="value"></param>
+        void SetNamedProperty(StdString name, V8Value.Decoded value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        bool DeleteNamedProperty(StdString name) => false;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="pValue"></param>
+        void GetIndexedProperty(int index, V8Value pValue);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="index"></param>
+        /// <param name="value"></param>
+        void SetIndexedProperty(int index, V8Value.Decoded value);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        bool DeleteIndexedProperty(int index) => false;
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="result"></param>
+        void GetEnumerator(V8Value result) => result.SetNonexistent();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="result"></param>
+        void GetAsyncEnumerator(V8Value result) => result.SetNonexistent();
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="names"></param>
+        void GetNamedPropertyNames(StdStringArray names) => names.SetElementCount(0);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="indices"></param>
+        void GetIndexedPropertyIndices(StdInt32Array indices) => indices.SetElementCount(0);
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="args"></param>
+        /// <param name="result"></param>
+        void InvokeMethod(StdString name, ReadOnlySpan<V8Value.Decoded> args, V8Value result)
+        {
+            GetNamedProperty(name, result, out _);
+            object method = result.GetHostObject();
+            ((InvokeHostObject)method)(args, result);
+        }
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="args"></param>
+    /// <param name="result"></param>
+    public delegate void InvokeHostObject(ReadOnlySpan<V8Value.Decoded> args, V8Value result);
+}
+
+namespace Demo
+{
+    using Microsoft.ClearScript.V8.Unsafe;
+
+    public sealed class Bomb : IV8HostObject
+    {
+        private Action<string> log;
+        private InvokeHostObject explode;
+
+        public Bomb(Action<string> log)
+        {
+            this.log = log;
+            explode = Explode;
+        }
+
+        private void Explode(ReadOnlySpan<V8Value.Decoded> args, V8Value result)
+        {
+            log("Boom!");
+            result.SetNonexistent();
+        }
+
+        public void GetNamedProperty(StdString name, V8Value value, out bool isConst)
+        {
+            if (name.Equals(nameof(explode)))
+            {
+                value.SetHostObject(explode);
+                isConst = true;
+            }
+            else
+            {
+                value.SetNonexistent();
+                isConst = true;
+            }
+        }
+
+        public void GetIndexedProperty(int index, V8Value value) => value.SetNonexistent();
+
+        public void SetNamedProperty(StdString name, V8Value.Decoded value) { }
+
+        public void SetIndexedProperty(int index, V8Value.Decoded value) { }
+    }
+}

--- a/ClearScript/V8/SplitProxy/IV8SplitProxyNative.cs
+++ b/ClearScript/V8/SplitProxy/IV8SplitProxyNative.cs
@@ -19,6 +19,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         StdString.Ptr StdString_New(string value);
         string StdString_GetValue(StdString.Ptr pString);
+        void StdString_GetValue(StdString.Ptr pString, out IntPtr pValue, out int length);
         void StdString_SetValue(StdString.Ptr pString, string value);
         void StdString_Delete(StdString.Ptr pString);
 

--- a/ClearScript/V8/SplitProxy/V8SplitProxyHelpers.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyHelpers.cs
@@ -81,7 +81,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
                     while (i < end)
                     {
-                        if (&i != &j)
+                        if (*i != *j)
                         {
                             return false;
                         }

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.Common.tt
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.Common.tt
@@ -90,6 +90,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Marshal.PtrToStringUni(pValue, length);
             }
 
+            void IV8SplitProxyNative.StdString_GetValue(StdString.Ptr pString, out IntPtr pValue, out int length)
+            {
+                pValue = StdString_GetValue(pString, out length);
+            }
+
             void IV8SplitProxyNative.StdString_SetValue(StdString.Ptr pString, string value)
             {
                 StdString_SetValue(pString, value, value.Length);

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
@@ -8,13 +8,13 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 {
     internal static partial class V8SplitProxyNative
     {
-        private static readonly IV8SplitProxyNative instance = CreateInstance();
+        public static readonly IV8SplitProxyNative Instance = CreateInstance();
 
         public static string GetVersion()
         {
             try
             {
-                return instance.V8SplitProxyNative_GetVersion();
+                return Instance.V8SplitProxyNative_GetVersion();
             }
             catch (EntryPointNotFoundException)
             {
@@ -25,15 +25,15 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         public static void Invoke(Action<IV8SplitProxyNative> action)
         {
             var previousScheduledException = MiscHelpers.Exchange(ref V8SplitProxyManaged.ScheduledException, null);
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                action(instance);
+                action(Instance);
                 ThrowScheduledException();
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
                 V8SplitProxyManaged.ScheduledException = previousScheduledException;
             }
         }
@@ -41,43 +41,43 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         public static T Invoke<T>(Func<IV8SplitProxyNative, T> func)
         {
             var previousScheduledException = MiscHelpers.Exchange(ref V8SplitProxyManaged.ScheduledException, null);
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                var result = func(instance);
+                var result = func(Instance);
                 ThrowScheduledException();
                 return result;
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
                 V8SplitProxyManaged.ScheduledException = previousScheduledException;
             }
         }
 
         public static void InvokeNoThrow(Action<IV8SplitProxyNative> action)
         {
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                action(instance);
+                action(Instance);
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
             }
         }
 
         public static T InvokeNoThrow<T>(Func<IV8SplitProxyNative, T> func)
         {
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
+            var previousMethodTable = Instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
             try
             {
-                return func(instance);
+                return func(Instance);
             }
             finally
             {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                Instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
             }
         }
 


### PR DESCRIPTION
Here is my current proposed solution to getting rid of all GC allocations when calling methods on host objects from JavaScript. The client code would implement the IV8HostObject interface and deal with all the callbacks itself. Functionality would be added to all the Std and V8 types in V8SplitProxyHelpers.cs so that they could be manipulated without GC allocations.

Please tell me if you would merge anything like this.