### PR TITLE
Eliminate lambdas from Invoke calls

### DIFF
--- a/ClearScript/V8/SplitProxy/NativeCallbackImpl.cs
+++ b/ClearScript/V8/SplitProxy/NativeCallbackImpl.cs
@@ -21,7 +21,10 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public void Invoke()
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.NativeCallback_Invoke(Handle));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.NativeCallback_Invoke(Handle);
+            }
         }
 
         #endregion

--- a/ClearScript/V8/SplitProxy/V8ContextProxyImpl.cs
+++ b/ClearScript/V8/SplitProxy/V8ContextProxyImpl.cs
@@ -22,76 +22,135 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public override UIntPtr MaxIsolateHeapSize
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Context_GetMaxIsolateHeapSize(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Context_SetMaxIsolateHeapSize(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Context_GetMaxIsolateHeapSize(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_SetMaxIsolateHeapSize(Handle, value);
+                }
+            }
         }
 
         public override TimeSpan IsolateHeapSizeSampleInterval
         {
-            get => V8SplitProxyNative.Invoke(instance => TimeSpan.FromMilliseconds(instance.V8Context_GetIsolateHeapSizeSampleInterval(Handle)));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Context_SetIsolateHeapSizeSampleInterval(Handle, value.TotalMilliseconds));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return TimeSpan.FromMilliseconds(instance.V8Context_GetIsolateHeapSizeSampleInterval(Handle));
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_SetIsolateHeapSizeSampleInterval(Handle, value.TotalMilliseconds);
+                }
+            }
         }
 
         public override UIntPtr MaxIsolateStackUsage
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Context_GetMaxIsolateStackUsage(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Context_SetMaxIsolateStackUsage(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Context_GetMaxIsolateStackUsage(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_SetMaxIsolateStackUsage(Handle, value);
+                }
+            }
         }
 
         public override void InvokeWithLock(Action action)
         {
             using (var actionScope = V8ProxyHelpers.CreateAddRefHostObjectScope(action))
             {
-                var pAction = actionScope.Value;
-                V8SplitProxyNative.Invoke(instance => instance.V8Context_InvokeWithLock(Handle, pAction));
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_InvokeWithLock(Handle, actionScope.Value);
+                }
             }
         }
 
         public override object GetRootItem()
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Context_GetRootItem(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Context_GetRootItem(Handle);
+            }
         }
 
         public override void AddGlobalItem(string name, object item, bool globalMembers)
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_AddGlobalItem(Handle, name, item, globalMembers));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_AddGlobalItem(Handle, name, item, globalMembers);
+            }
         }
 
         public override void AwaitDebuggerAndPause()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_AwaitDebuggerAndPause(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_AwaitDebuggerAndPause(Handle);
+            }
         }
 
         public override void CancelAwaitDebugger()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_CancelAwaitDebugger(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_CancelAwaitDebugger(Handle);
+            }
         }
 
         public override object Execute(UniqueDocumentInfo documentInfo, string code, bool evaluate)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Context_ExecuteCode(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code,
-                evaluate
-            ));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Context_ExecuteCode(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code,
+                    evaluate
+                );
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code)
         {
-            return new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Context_Compile(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code
-            )));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Context_Compile(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code
+                ));
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code, V8CacheKind cacheKind, out byte[] cacheBytes)
@@ -102,21 +161,20 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Compile(documentInfo, code);
             }
 
-            byte[] tempCacheBytes = null;
-            var script = new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Context_CompileProducingCache(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code,
-                cacheKind,
-                out tempCacheBytes
-            )));
-
-            cacheBytes = tempCacheBytes;
-            return script;
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Context_CompileProducingCache(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code,
+                    cacheKind,
+                    out cacheBytes
+                ));
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code, V8CacheKind cacheKind, byte[] cacheBytes, out bool cacheAccepted)
@@ -127,22 +185,21 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Compile(documentInfo, code);
             }
 
-            var tempCacheAccepted = false;
-            var script = new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Context_CompileConsumingCache(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code,
-                cacheKind,
-                cacheBytes,
-                out tempCacheAccepted
-            )));
-
-            cacheAccepted = tempCacheAccepted;
-            return script;
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Context_CompileConsumingCache(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code,
+                    cacheKind,
+                    cacheBytes,
+                    out cacheAccepted
+                ));
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code, V8CacheKind cacheKind, ref byte[] cacheBytes, out V8CacheResult cacheResult)
@@ -168,21 +225,22 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return script;
             }
 
-            var tempCacheResult = V8CacheResult.Disabled;
-            script = new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Context_CompileUpdatingCache(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code,
-                cacheKind,
-                ref tempCacheBytes,
-                out tempCacheResult
-            )));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                script = new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Context_CompileUpdatingCache(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code,
+                    cacheKind,
+                    ref cacheBytes,
+                    out cacheResult
+                ));
+            }
 
-            cacheResult = tempCacheResult;
             if (cacheResult == V8CacheResult.Updated)
             {
                 cacheBytes = tempCacheBytes;
@@ -198,33 +256,68 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 throw new ArgumentException("Invalid compiled script", nameof(script));
             }
 
-            return V8SplitProxyNative.Invoke(instance => instance.V8Context_ExecuteScript(
-                Handle,
-                scriptImpl.Handle,
-                evaluate
-            ));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Context_ExecuteScript(
+                    Handle,
+                    scriptImpl.Handle,
+                    evaluate
+                );
+            }
         }
 
         public override void Interrupt()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_Interrupt(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_Interrupt(Handle);
+            }
         }
 
         public override void CancelInterrupt()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_CancelInterrupt(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_CancelInterrupt(Handle);
+            }
         }
 
         public override bool EnableIsolateInterruptPropagation
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Context_GetEnableIsolateInterruptPropagation(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Context_SetEnableIsolateInterruptPropagation(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Context_GetEnableIsolateInterruptPropagation(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_SetEnableIsolateInterruptPropagation(Handle, value);
+                }
+            }
         }
 
         public override bool DisableIsolateHeapSizeViolationInterrupt
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Context_GetDisableIsolateHeapSizeViolationInterrupt(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Context_SetDisableIsolateHeapSizeViolationInterrupt(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Context_GetDisableIsolateHeapSizeViolationInterrupt(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_SetDisableIsolateHeapSizeViolationInterrupt(Handle, value);
+                }
+            }
         }
 
         public override V8RuntimeHeapInfo GetIsolateHeapInfo()
@@ -236,7 +329,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             var usedHeapSize = 0UL;
             var heapSizeLimit = 0UL;
             var totalExternalSize = 0UL;
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_GetIsolateHeapStatistics(Handle, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out totalAvailableSize, out usedHeapSize, out heapSizeLimit, out totalExternalSize));
+
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_GetIsolateHeapStatistics(Handle, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out totalAvailableSize, out usedHeapSize, out heapSizeLimit, out totalExternalSize);
+            }
 
             return new V8RuntimeHeapInfo
             {
@@ -253,30 +350,49 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         public override V8Runtime.Statistics GetIsolateStatistics()
         {
             var statistics = new V8Runtime.Statistics();
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_GetIsolateStatistics(Handle, out statistics.ScriptCount, out statistics.ScriptCacheSize, out statistics.ModuleCount, out statistics.PostedTaskCounts, out statistics.InvokedTaskCounts));
+
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_GetIsolateStatistics(Handle, out statistics.ScriptCount, out statistics.ScriptCacheSize, out statistics.ModuleCount, out statistics.PostedTaskCounts, out statistics.InvokedTaskCounts);
+            }
+
             return statistics;
         }
 
         public override V8ScriptEngine.Statistics GetStatistics()
         {
             var statistics = new V8ScriptEngine.Statistics();
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_GetStatistics(Handle, out statistics.ScriptCount, out statistics.ModuleCount, out statistics.ModuleCacheSize));
+
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_GetStatistics(Handle, out statistics.ScriptCount, out statistics.ModuleCount, out statistics.ModuleCacheSize);
+            }
+
             return statistics;
         }
 
         public override void CollectGarbage(bool exhaustive)
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_CollectGarbage(Handle, exhaustive));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_CollectGarbage(Handle, exhaustive);
+            }
         }
 
         public override void OnAccessSettingsChanged()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_OnAccessSettingsChanged(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_OnAccessSettingsChanged(Handle);
+            }
         }
 
         public override bool BeginCpuProfile(string name, V8CpuProfileFlags flags)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Context_BeginCpuProfile(Handle, name, flags.HasFlag(V8CpuProfileFlags.EnableSampleCollection)));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Context_BeginCpuProfile(Handle, name, flags.HasFlag(V8CpuProfileFlags.EnableSampleCollection));
+            }
         }
 
         public override V8.V8CpuProfile EndCpuProfile(string name)
@@ -286,8 +402,10 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             Action<V8CpuProfile.Ptr> action = pProfile => V8CpuProfile.ProcessProfile(Handle, pProfile, profile);
             using (var actionScope = V8ProxyHelpers.CreateAddRefHostObjectScope(action))
             {
-                var pAction = actionScope.Value;
-                V8SplitProxyNative.Invoke(instance => instance.V8Context_EndCpuProfile(Handle, name, pAction));
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_EndCpuProfile(Handle, name, actionScope.Value);
+                }
             }
 
             return profile;
@@ -295,21 +413,39 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public override void CollectCpuProfileSample()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Context_CollectCpuProfileSample(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Context_CollectCpuProfileSample(Handle);
+            }
         }
 
         public override uint CpuProfileSampleInterval
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Context_GetCpuProfileSampleInterval(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Context_SetCpuProfileSampleInterval(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Context_GetCpuProfileSampleInterval(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_SetCpuProfileSampleInterval(Handle, value);
+                }
+            }
         }
 
         public override void WriteIsolateHeapSnapshot(Stream stream)
         {
             using (var streamScope = V8ProxyHelpers.CreateAddRefHostObjectScope(stream))
             {
-                var pStream = streamScope.Value;
-                V8SplitProxyNative.Invoke(instance => instance.V8Context_WriteIsolateHeapSnapshot(Handle, pStream));
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Context_WriteIsolateHeapSnapshot(Handle, streamScope.Value);
+                }
             }
         }
 

--- a/ClearScript/V8/SplitProxy/V8DebugListenerImpl.cs
+++ b/ClearScript/V8/SplitProxy/V8DebugListenerImpl.cs
@@ -20,17 +20,26 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public void ConnectClient()
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8DebugCallback_ConnectClient(Handle));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8DebugCallback_ConnectClient(Handle);
+            }
         }
 
         public void SendCommand(string command)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8DebugCallback_SendCommand(Handle, command));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8DebugCallback_SendCommand(Handle, command);
+            }
         }
 
         public void DisconnectClient()
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8DebugCallback_DisconnectClient(Handle));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8DebugCallback_DisconnectClient(Handle);
+            }
         }
 
         #endregion

--- a/ClearScript/V8/SplitProxy/V8EntityHolder.cs
+++ b/ClearScript/V8/SplitProxy/V8EntityHolder.cs
@@ -30,19 +30,23 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public void ReleaseEntity()
         {
-            var tempHandle = handle;
-            if (tempHandle != V8Entity.Handle.Empty)
+            if (handle != V8Entity.Handle.Empty)
             {
-                V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Entity_Release(tempHandle));
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.V8Entity_Release(handle);
+                }
             }
         }
 
         public static void Destroy(ref V8EntityHolder holder)
         {
-            var tempHandle = holder.handle;
-            if (tempHandle != V8Entity.Handle.Empty)
+            if (holder.handle != V8Entity.Handle.Empty)
             {
-                V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Entity_DestroyHandle(tempHandle));
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.V8Entity_DestroyHandle(holder.handle);
+                }
             }
 
             if (holder.registered)

--- a/ClearScript/V8/SplitProxy/V8IsolateProxyImpl.cs
+++ b/ClearScript/V8/SplitProxy/V8IsolateProxyImpl.cs
@@ -15,68 +15,125 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public V8IsolateProxyImpl(string name, V8RuntimeConstraints constraints, V8RuntimeFlags flags, int debugPort)
         {
-            holder = new V8EntityHolder("V8 runtime", () => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_Create(
-                name,
-                constraints?.MaxNewSpaceSize ?? -1,
-                constraints?.MaxOldSpaceSize ?? -1,
-                constraints?.HeapExpansionMultiplier ?? 0,
-                constraints?.MaxArrayBufferAllocation ?? ulong.MaxValue,
-                flags,
-                debugPort
-            )));
+            holder = new V8EntityHolder("V8 runtime", () =>
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Isolate_Create(
+                        name,
+                        constraints?.MaxNewSpaceSize ?? -1,
+                        constraints?.MaxOldSpaceSize ?? -1,
+                        constraints?.HeapExpansionMultiplier ?? 0,
+                        constraints?.MaxArrayBufferAllocation ?? ulong.MaxValue,
+                        flags,
+                        debugPort
+                    );
+                }
+            });
         }
 
         public V8Context.Handle CreateContext(string name, V8ScriptEngineFlags flags, int debugPort)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Isolate_CreateContext(
-                Handle,
-                name,
-                flags,
-                debugPort
-            ));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Isolate_CreateContext(
+                    Handle,
+                    name,
+                    flags,
+                    debugPort
+                );
+            }
         }
 
         #region V8IsolateProxy overrides
 
         public override UIntPtr MaxHeapSize
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_GetMaxHeapSize(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_SetMaxHeapSize(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Isolate_GetMaxHeapSize(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_SetMaxHeapSize(Handle, value);
+                }
+            }
         }
 
         public override TimeSpan HeapSizeSampleInterval
         {
-            get => V8SplitProxyNative.Invoke(instance => TimeSpan.FromMilliseconds(instance.V8Isolate_GetHeapSizeSampleInterval(Handle)));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_SetHeapSizeSampleInterval(Handle, value.TotalMilliseconds));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return TimeSpan.FromMilliseconds(instance.V8Isolate_GetHeapSizeSampleInterval(Handle));
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_SetHeapSizeSampleInterval(Handle, value.TotalMilliseconds);
+                }
+            }
         }
 
         public override UIntPtr MaxStackUsage
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_GetMaxStackUsage(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_SetMaxStackUsage(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Isolate_GetMaxStackUsage(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_SetMaxStackUsage(Handle, value);
+                }
+            }
         }
 
         public override void AwaitDebuggerAndPause()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Isolate_AwaitDebuggerAndPause(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Isolate_AwaitDebuggerAndPause(Handle);
+            }
         }
 
         public override void CancelAwaitDebugger()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Isolate_CancelAwaitDebugger(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Isolate_CancelAwaitDebugger(Handle);
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code)
         {
-            return new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Isolate_Compile(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code
-            )));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Isolate_Compile(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code
+                ));
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code, V8CacheKind cacheKind, out byte[] cacheBytes)
@@ -87,21 +144,20 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Compile(documentInfo, code);
             }
 
-            byte[] tempCacheBytes = null;
-            var script = new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Isolate_CompileProducingCache(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code,
-                cacheKind,
-                out tempCacheBytes
-            )));
-
-            cacheBytes = tempCacheBytes;
-            return script;
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Isolate_CompileProducingCache(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code,
+                    cacheKind,
+                    out cacheBytes
+                ));
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code, V8CacheKind cacheKind, byte[] cacheBytes, out bool cacheAccepted)
@@ -112,22 +168,21 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return Compile(documentInfo, code);
             }
 
-            var tempCacheAccepted = false;
-            var script = new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Isolate_CompileConsumingCache(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code,
-                cacheKind,
-                cacheBytes,
-                out tempCacheAccepted
-            )));
-
-            cacheAccepted = tempCacheAccepted;
-            return script;
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Isolate_CompileConsumingCache(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code,
+                    cacheKind,
+                    cacheBytes,
+                    out cacheAccepted
+                ));
+            }
         }
 
         public override V8.V8Script Compile(UniqueDocumentInfo documentInfo, string code, V8CacheKind cacheKind, ref byte[] cacheBytes, out V8CacheResult cacheResult)
@@ -153,21 +208,22 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 return script;
             }
 
-            var tempCacheResult = V8CacheResult.Disabled;
-            script = new V8ScriptImpl(documentInfo, code.GetDigest(), V8SplitProxyNative.Invoke(instance => instance.V8Isolate_CompileUpdatingCache(
-                Handle,
-                MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
-                MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
-                documentInfo.UniqueId,
-                documentInfo.Category.Kind,
-                V8ProxyHelpers.AddRefHostObject(documentInfo),
-                code,
-                cacheKind,
-                ref tempCacheBytes,
-                out tempCacheResult
-            )));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                script = new V8ScriptImpl(documentInfo, code.GetDigest(), instance.V8Isolate_CompileUpdatingCache(
+                    Handle,
+                    MiscHelpers.GetUrlOrPath(documentInfo.Uri, documentInfo.UniqueName),
+                    MiscHelpers.GetUrlOrPath(documentInfo.SourceMapUri, string.Empty),
+                    documentInfo.UniqueId,
+                    documentInfo.Category.Kind,
+                    V8ProxyHelpers.AddRefHostObject(documentInfo),
+                    code,
+                    cacheKind,
+                    ref tempCacheBytes,
+                    out cacheResult
+                ));
+            }
 
-            cacheResult = tempCacheResult;
             if (cacheResult == V8CacheResult.Updated)
             {
                 cacheBytes = tempCacheBytes;
@@ -178,14 +234,40 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public override bool EnableInterruptPropagation
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_GetEnableInterruptPropagation(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_SetEnableInterruptPropagation(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Isolate_GetEnableInterruptPropagation(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_SetEnableInterruptPropagation(Handle, value);
+                }
+            }
         }
 
         public override bool DisableHeapSizeViolationInterrupt
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_GetDisableHeapSizeViolationInterrupt(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_SetDisableHeapSizeViolationInterrupt(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Isolate_GetDisableHeapSizeViolationInterrupt(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_SetDisableHeapSizeViolationInterrupt(Handle, value);
+                }
+            }
         }
 
         public override V8RuntimeHeapInfo GetHeapInfo()
@@ -197,7 +279,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             var usedHeapSize = 0UL;
             var heapSizeLimit = 0UL;
             var totalExternalSize = 0UL;
-            V8SplitProxyNative.Invoke(instance => instance.V8Isolate_GetHeapStatistics(Handle, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out totalAvailableSize, out usedHeapSize, out heapSizeLimit, out totalExternalSize));
+
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Isolate_GetHeapStatistics(Handle, out totalHeapSize, out totalHeapSizeExecutable, out totalPhysicalSize, out totalAvailableSize, out usedHeapSize, out heapSizeLimit, out totalExternalSize);
+            }
 
             return new V8RuntimeHeapInfo
             {
@@ -214,18 +300,29 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         public override V8Runtime.Statistics GetStatistics()
         {
             var statistics = new V8Runtime.Statistics();
-            V8SplitProxyNative.Invoke(instance => instance.V8Isolate_GetStatistics(Handle, out statistics.ScriptCount, out statistics.ScriptCacheSize, out statistics.ModuleCount, out statistics.PostedTaskCounts, out statistics.InvokedTaskCounts));
+
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Isolate_GetStatistics(Handle, out statistics.ScriptCount, out statistics.ScriptCacheSize, out statistics.ModuleCount, out statistics.PostedTaskCounts, out statistics.InvokedTaskCounts);
+            }
+
             return statistics;
         }
 
         public override void CollectGarbage(bool exhaustive)
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Isolate_CollectGarbage(Handle, exhaustive));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Isolate_CollectGarbage(Handle, exhaustive);
+            }
         }
 
         public override bool BeginCpuProfile(string name, V8CpuProfileFlags flags)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Isolate_BeginCpuProfile(Handle, name, flags.HasFlag(V8CpuProfileFlags.EnableSampleCollection)));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Isolate_BeginCpuProfile(Handle, name, flags.HasFlag(V8CpuProfileFlags.EnableSampleCollection));
+            }
         }
 
         public override V8.V8CpuProfile EndCpuProfile(string name)
@@ -235,8 +332,10 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             Action<V8CpuProfile.Ptr> action = pProfile => V8CpuProfile.ProcessProfile(Handle, pProfile, profile);
             using (var actionScope = V8ProxyHelpers.CreateAddRefHostObjectScope(action))
             {
-                var pAction = actionScope.Value;
-                V8SplitProxyNative.Invoke(instance => instance.V8Isolate_EndCpuProfile(Handle, name, pAction));
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_EndCpuProfile(Handle, name, actionScope.Value);
+                }
             }
 
             return profile;
@@ -244,21 +343,39 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public override void CollectCpuProfileSample()
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Isolate_CollectCpuProfileSample(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Isolate_CollectCpuProfileSample(Handle);
+            }
         }
 
         public override uint CpuProfileSampleInterval
         {
-            get => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_GetCpuProfileSampleInterval(Handle));
-            set => V8SplitProxyNative.Invoke(instance => instance.V8Isolate_SetCpuProfileSampleInterval(Handle, value));
+            get
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    return instance.V8Isolate_GetCpuProfileSampleInterval(Handle);
+                }
+            }
+
+            set
+            {
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_SetCpuProfileSampleInterval(Handle, value);
+                }
+            }
         }
 
         public override void WriteHeapSnapshot(Stream stream)
         {
             using (var streamScope = V8ProxyHelpers.CreateAddRefHostObjectScope(stream))
             {
-                var pStream = streamScope.Value;
-                V8SplitProxyNative.Invoke(instance => instance.V8Isolate_WriteHeapSnapshot(Handle, pStream));
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Isolate_WriteHeapSnapshot(Handle, streamScope.Value);
+                }
             }
         }
 

--- a/ClearScript/V8/SplitProxy/V8ObjectImpl.cs
+++ b/ClearScript/V8/SplitProxy/V8ObjectImpl.cs
@@ -98,60 +98,90 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public object GetProperty(string name)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_GetNamedProperty(Handle, name));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_GetNamedProperty(Handle, name);
+            }
         }
 
         public bool TryGetProperty(string name, out object value)
         {
-            object tempValue = null;
-            var result = V8SplitProxyNative.Invoke(instance => instance.V8Object_TryGetNamedProperty(Handle, name, out tempValue));
-            value = tempValue;
-            return result;
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_TryGetNamedProperty(Handle, name, out value);
+            }
         }
 
         public void SetProperty(string name, object value)
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Object_SetNamedProperty(Handle, name, value));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Object_SetNamedProperty(Handle, name, value);
+            }
         }
 
         public bool DeleteProperty(string name)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_DeleteNamedProperty(Handle, name));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_DeleteNamedProperty(Handle, name);
+            }
         }
 
         public string[] GetPropertyNames(bool includeIndices)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_GetPropertyNames(Handle, includeIndices));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_GetPropertyNames(Handle, includeIndices);
+            }
         }
 
         public object GetProperty(int index)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_GetIndexedProperty(Handle, index));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_GetIndexedProperty(Handle, index);
+            }
         }
 
         public void SetProperty(int index, object value)
         {
-            V8SplitProxyNative.Invoke(instance => instance.V8Object_SetIndexedProperty(Handle, index, value));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                instance.V8Object_SetIndexedProperty(Handle, index, value);
+            }
         }
 
         public bool DeleteProperty(int index)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_DeleteIndexedProperty(Handle, index));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_DeleteIndexedProperty(Handle, index);
+            }
         }
 
         public int[] GetPropertyIndices()
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_GetPropertyIndices(Handle));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_GetPropertyIndices(Handle);
+            }
         }
 
         public object Invoke(bool asConstructor, object[] args)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_Invoke(Handle, asConstructor, args));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_Invoke(Handle, asConstructor, args);
+            }
         }
 
         public object InvokeMethod(string name, object[] args)
         {
-            return V8SplitProxyNative.Invoke(instance => instance.V8Object_InvokeMethod(Handle, name, args));
+            using (V8SplitProxyNative.Invoke(out var instance))
+            {
+                return instance.V8Object_InvokeMethod(Handle, name, args);
+            }
         }
 
         public bool IsPromise => Subtype == V8Value.Subtype.Promise;
@@ -247,7 +277,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 var offset = 0UL;
                 var size = 0UL;
                 var length = 0UL;
-                V8SplitProxyNative.Invoke(instance => instance.V8Object_GetArrayBufferOrViewInfo(Handle, out arrayBuffer, out offset, out size, out length));
+
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Object_GetArrayBufferOrViewInfo(Handle, out arrayBuffer, out offset, out size, out length);
+                }
+
                 return new V8ArrayBufferOrViewInfo(kind, arrayBuffer, offset, size, length);
             }
 
@@ -258,8 +293,10 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         {
             using (var actionScope = V8ProxyHelpers.CreateAddRefHostObjectScope(action))
             {
-                var pAction = actionScope.Value;
-                V8SplitProxyNative.Invoke(instance => instance.V8Object_InvokeWithArrayBufferOrViewData(Handle, pAction));
+                using (V8SplitProxyNative.Invoke(out var instance))
+                {
+                    instance.V8Object_InvokeWithArrayBufferOrViewData(Handle, actionScope.Value);
+                }
             }
         }
 

--- a/ClearScript/V8/SplitProxy/V8SplitProxyHelpers.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyHelpers.cs
@@ -16,17 +16,35 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(string value = null)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdString_New(value ?? string.Empty), instance.StdString_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdString_New(value ?? string.Empty);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdString_Delete(ptr);
+                }
+            });
         }
 
         public static string GetValue(Ptr pString)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdString_GetValue(pString));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdString_GetValue(pString);
+            }
         }
 
         public static void SetValue(Ptr pString, string value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdString_SetValue(pString, value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdString_SetValue(pString, value);
+            }
         }
 
         #region Nested type: Ptr
@@ -60,27 +78,57 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(int elementCount = 0)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdStringArray_New(elementCount), instance.StdStringArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdStringArray_New(elementCount);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdStringArray_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(string[] array)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => NewFromArray(instance, array), instance.StdStringArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return NewFromArray(instance, array);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdStringArray_Delete(ptr);
+                }
+            });
         }
 
         public static int GetElementCount(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdStringArray_GetElementCount(pArray));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdStringArray_GetElementCount(pArray);
+            }
         }
 
         public static void SetElementCount(Ptr pArray, int elementCount)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdStringArray_SetElementCount(pArray, elementCount));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdStringArray_SetElementCount(pArray, elementCount);
+            }
         }
 
         public static string[] ToArray(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = instance.StdStringArray_GetElementCount(pArray);
                 var array = new string[elementCount];
@@ -94,12 +142,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
 
                 return array;
-            });
+            };
         }
 
         public static void CopyFromArray(Ptr pArray, string[] array)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = array?.Length ?? 0;
                 instance.StdStringArray_SetElementCount(pArray, elementCount);
@@ -108,7 +156,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 {
                     instance.StdStringArray_SetElement(pArray, index, array[index]);
                 }
-            });
+            };
         }
 
         private static Ptr NewFromArray(IV8SplitProxyNative instance, string[] array)
@@ -158,27 +206,57 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(int elementCount = 0)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdByteArray_New(elementCount), instance.StdByteArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdByteArray_New(elementCount);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdByteArray_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(byte[] array)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => NewFromArray(instance, array), instance.StdByteArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return NewFromArray(instance, array);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdByteArray_Delete(ptr);
+                }
+            });
         }
 
         public static int GetElementCount(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdByteArray_GetElementCount(pArray));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdByteArray_GetElementCount(pArray);
+            }
         }
 
         public static void SetElementCount(Ptr pArray, int elementCount)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdByteArray_SetElementCount(pArray, elementCount));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdByteArray_SetElementCount(pArray, elementCount);
+            }
         }
 
         public static byte[] ToArray(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = instance.StdByteArray_GetElementCount(pArray);
                 var array = new byte[elementCount];
@@ -189,12 +267,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
 
                 return array;
-            });
+            };
         }
 
         public static void CopyFromArray(Ptr pArray, byte[] array)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = array?.Length ?? 0;
                 instance.StdByteArray_SetElementCount(pArray, elementCount);
@@ -203,7 +281,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 {
                     Marshal.Copy(array, 0, instance.StdByteArray_GetData(pArray), elementCount);
                 }
-            });
+            };
         }
 
         private static Ptr NewFromArray(IV8SplitProxyNative instance, byte[] array)
@@ -250,27 +328,57 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(int elementCount = 0)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdInt32Array_New(elementCount), instance.StdInt32Array_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdInt32Array_New(elementCount);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdInt32Array_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(int[] array)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => NewFromArray(instance, array), instance.StdInt32Array_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return NewFromArray(instance, array);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdInt32Array_Delete(ptr);
+                }
+            });
         }
 
         public static int GetElementCount(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdInt32Array_GetElementCount(pArray));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdInt32Array_GetElementCount(pArray);
+            }
         }
 
         public static void SetElementCount(Ptr pArray, int elementCount)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdInt32Array_SetElementCount(pArray, elementCount));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdInt32Array_SetElementCount(pArray, elementCount);
+            }
         }
 
         public static int[] ToArray(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = instance.StdInt32Array_GetElementCount(pArray);
                 var array = new int[elementCount];
@@ -281,12 +389,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
 
                 return array;
-            });
+            };
         }
 
         public static void CopyFromArray(Ptr pArray, int[] array)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = array?.Length ?? 0;
                 instance.StdInt32Array_SetElementCount(pArray, elementCount);
@@ -295,7 +403,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 {
                     Marshal.Copy(array, 0, instance.StdInt32Array_GetData(pArray), elementCount);
                 }
-            });
+            };
         }
 
         private static Ptr NewFromArray(IV8SplitProxyNative instance, int[] array)
@@ -342,27 +450,57 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(int elementCount = 0)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdUInt32Array_New(elementCount), instance.StdUInt32Array_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdUInt32Array_New(elementCount);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdUInt32Array_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(uint[] array)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => NewFromArray(instance, array), instance.StdUInt32Array_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return NewFromArray(instance, array);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdUInt32Array_Delete(ptr);
+                }
+            });
         }
 
         public static int GetElementCount(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdUInt32Array_GetElementCount(pArray));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdUInt32Array_GetElementCount(pArray);
+            }
         }
 
         public static void SetElementCount(Ptr pArray, int elementCount)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdUInt32Array_SetElementCount(pArray, elementCount));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdUInt32Array_SetElementCount(pArray, elementCount);
+            }
         }
 
         public static uint[] ToArray(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = instance.StdUInt32Array_GetElementCount(pArray);
                 var array = new uint[elementCount];
@@ -373,12 +511,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
 
                 return array;
-            });
+            };
         }
 
         public static void CopyFromArray(Ptr pArray, uint[] array)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = array?.Length ?? 0;
                 instance.StdUInt32Array_SetElementCount(pArray, elementCount);
@@ -387,7 +525,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 {
                     UnmanagedMemoryHelpers.Copy(array, 0, (ulong)elementCount, instance.StdUInt32Array_GetData(pArray));
                 }
-            });
+            };
         }
 
         private static Ptr NewFromArray(IV8SplitProxyNative instance, uint[] array)
@@ -434,27 +572,57 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(int elementCount = 0)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdUInt64Array_New(elementCount), instance.StdUInt64Array_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdUInt64Array_New(elementCount);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdUInt64Array_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(ulong[] array)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => NewFromArray(instance, array), instance.StdUInt64Array_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return NewFromArray(instance, array);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdUInt64Array_Delete(ptr);
+                }
+            });
         }
 
         public static int GetElementCount(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdUInt64Array_GetElementCount(pArray));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdUInt64Array_GetElementCount(pArray);
+            }
         }
 
         public static void SetElementCount(Ptr pArray, int elementCount)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdUInt64Array_SetElementCount(pArray, elementCount));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdUInt64Array_SetElementCount(pArray, elementCount);
+            }
         }
 
         public static ulong[] ToArray(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = instance.StdUInt64Array_GetElementCount(pArray);
                 var array = new ulong[elementCount];
@@ -465,12 +633,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
 
                 return array;
-            });
+            };
         }
 
         public static void CopyFromArray(Ptr pArray, ulong[] array)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = array?.Length ?? 0;
                 instance.StdUInt64Array_SetElementCount(pArray, elementCount);
@@ -479,7 +647,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 {
                     UnmanagedMemoryHelpers.Copy(array, 0, (ulong)elementCount, instance.StdUInt64Array_GetData(pArray));
                 }
-            });
+            };
         }
 
         private static Ptr NewFromArray(IV8SplitProxyNative instance, ulong[] array)
@@ -526,27 +694,57 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(int elementCount = 0)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdPtrArray_New(elementCount), instance.StdPtrArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdPtrArray_New(elementCount);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdPtrArray_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(IntPtr[] array)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => NewFromArray(instance, array), instance.StdPtrArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return NewFromArray(instance, array);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdPtrArray_Delete(ptr);
+                }
+            });
         }
 
         public static int GetElementCount(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdPtrArray_GetElementCount(pArray));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdPtrArray_GetElementCount(pArray);
+            }
         }
 
         public static void SetElementCount(Ptr pArray, int elementCount)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdPtrArray_SetElementCount(pArray, elementCount));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdPtrArray_SetElementCount(pArray, elementCount);
+            }
         }
 
         public static IntPtr[] ToArray(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = instance.StdPtrArray_GetElementCount(pArray);
                 var array = new IntPtr[elementCount];
@@ -557,12 +755,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
 
                 return array;
-            });
+            };
         }
 
         public static void CopyFromArray(Ptr pArray, IntPtr[] array)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = array?.Length ?? 0;
                 instance.StdPtrArray_SetElementCount(pArray, elementCount);
@@ -571,7 +769,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 {
                     Marshal.Copy(array, 0, instance.StdPtrArray_GetData(pArray), elementCount);
                 }
-            });
+            };
         }
 
         private static Ptr NewFromArray(IV8SplitProxyNative instance, IntPtr[] array)
@@ -618,27 +816,57 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public static IScope<Ptr> CreateScope(int elementCount = 0)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => instance.StdV8ValueArray_New(elementCount), instance.StdV8ValueArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.StdV8ValueArray_New(elementCount);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdV8ValueArray_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(object[] array)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(() => NewFromArray(instance, array), instance.StdV8ValueArray_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return NewFromArray(instance, array);
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.StdV8ValueArray_Delete(ptr);
+                }
+            });
         }
 
         public static int GetElementCount(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.StdV8ValueArray_GetElementCount(pArray));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.StdV8ValueArray_GetElementCount(pArray);
+            }
         }
 
         public static void SetElementCount(Ptr pArray, int elementCount)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.StdV8ValueArray_SetElementCount(pArray, elementCount));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.StdV8ValueArray_SetElementCount(pArray, elementCount);
+            }
         }
 
         public static object[] ToArray(Ptr pArray)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = instance.StdV8ValueArray_GetElementCount(pArray);
                 var array = new object[elementCount];
@@ -653,12 +881,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 }
 
                 return array;
-            });
+            };
         }
 
         public static void CopyFromArray(Ptr pArray, object[] array)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance =>
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
             {
                 var elementCount = array?.Length ?? 0;
                 instance.StdV8ValueArray_SetElementCount(pArray, elementCount);
@@ -671,7 +899,7 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                         V8Value.Set(GetElementPtr(pElements, index), array[index]);
                     }
                 }
-            });
+            };
         }
 
         private static Ptr NewFromArray(IV8SplitProxyNative instance, object[] array)
@@ -726,7 +954,19 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         public static IScope<Ptr> CreateScope()
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => Scope.Create(instance.V8Value_New, instance.V8Value_Delete));
+            return Scope.Create(() =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    return instance.V8Value_New();
+                }
+            }, ptr =>
+            {
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    instance.V8Value_Delete(ptr);
+                }
+            });
         }
 
         public static IScope<Ptr> CreateScope(object obj)
@@ -898,7 +1138,12 @@ namespace Microsoft.ClearScript.V8.SplitProxy
         public static object Get(Ptr pV8Value)
         {
             var decoded = default(Decoded);
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_Decode(pV8Value, out decoded));
+
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_Decode(pV8Value, out decoded);
+            }
+
             return decoded.Get();
         }
 
@@ -931,47 +1176,74 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         private static void SetNonexistent(Ptr pV8Value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetNonexistent(pV8Value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetNonexistent(pV8Value);
+            }
         }
 
         private static void SetUndefined(Ptr pV8Value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetUndefined(pV8Value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetUndefined(pV8Value);
+            }
         }
 
         private static void SetNull(Ptr pV8Value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetNull(pV8Value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetNull(pV8Value);
+            }
         }
 
         private static void SetBoolean(Ptr pV8Value, bool value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetBoolean(pV8Value, value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetBoolean(pV8Value, value);
+            }
         }
 
         private static void SetNumeric(Ptr pV8Value, double value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetNumber(pV8Value, value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetNumber(pV8Value, value);
+            }
         }
 
         private static void SetNumeric(Ptr pV8Value, int value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetInt32(pV8Value, value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetInt32(pV8Value, value);
+            }
         }
 
         private static void SetNumeric(Ptr pV8Value, uint value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetUInt32(pV8Value, value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetUInt32(pV8Value, value);
+            }
         }
 
         private static void SetString(Ptr pV8Value, string value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetString(pV8Value, value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetString(pV8Value, value);
+            }
         }
 
         private static void SetDateTime(Ptr pV8Value, DateTime value)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetDateTime(pV8Value, (value.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetDateTime(pV8Value, (value.ToUniversalTime() - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalMilliseconds);
+            }
         }
 
         private static void SetBigInt(Ptr pV8Value, BigInteger value)
@@ -984,17 +1256,27 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             }
 
             var bytes = value.ToByteArray();
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetBigInt(pV8Value, signBit, bytes));
+
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetBigInt(pV8Value, signBit, bytes);
+            }
         }
 
         private static void SetV8Object(Ptr pV8Value, V8ObjectImpl v8ObjectImpl)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetV8Object(pV8Value, v8ObjectImpl.Handle, v8ObjectImpl.Subtype, v8ObjectImpl.Flags));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetV8Object(pV8Value, v8ObjectImpl.Handle, v8ObjectImpl.Subtype, v8ObjectImpl.Flags);
+            }
         }
 
         private static void SetHostObject(Ptr pV8Value, object obj)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Value_SetHostObject(pV8Value, V8ProxyHelpers.AddRefHostObject(obj)));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8Value_SetHostObject(pV8Value, V8ProxyHelpers.AddRefHostObject(obj));
+            }
         }
 
         #region Nested type: Type
@@ -1201,7 +1483,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             var endTimestamp = 0UL;
             var sampleCount = 0;
             var pRootNode = Node.Ptr.Null;
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8CpuProfile_GetInfo(pProfile, hEntity, out name, out startTimestamp, out endTimestamp, out sampleCount, out pRootNode));
+
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8CpuProfile_GetInfo(pProfile, hEntity, out name, out startTimestamp, out endTimestamp, out sampleCount, out pRootNode);
+            }
 
             profile.Name = name;
             profile.StartTimestamp = startTimestamp;
@@ -1221,7 +1507,13 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                     var nodeId = 0UL;
                     var timestamp = 0UL;
                     var sampleIndex = index;
-                    var found = V8SplitProxyNative.InvokeNoThrow(instance => instance.V8CpuProfile_GetSample(pProfile, sampleIndex, out nodeId, out timestamp));
+                    var found = false;
+
+                    using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                    {
+                        found = instance.V8CpuProfile_GetSample(pProfile, sampleIndex, out nodeId, out timestamp);
+                    }
+
                     if (found)
                     {
                         var node = profile.FindNode(nodeId);
@@ -1251,7 +1543,11 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             var hitCount = 0UL;
             var hitLineCount = 0U;
             var childCount = 0;
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8CpuProfileNode_GetInfo(pNode, hEntity, out nodeId, out scriptId, out scriptName, out functionName, out bailoutReason, out lineNumber, out columnNumber, out hitCount, out hitLineCount, out childCount));
+
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8CpuProfileNode_GetInfo(pNode, hEntity, out nodeId, out scriptId, out scriptName, out functionName, out bailoutReason, out lineNumber, out columnNumber, out hitCount, out hitLineCount, out childCount);
+            }
 
             var node = new V8.V8CpuProfile.Node
             {
@@ -1269,7 +1565,14 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             {
                 int[] lineNumbers = null;
                 uint[] hitCounts = null;
-                if (V8SplitProxyNative.InvokeNoThrow(instance => instance.V8CpuProfileNode_GetHitLines(pNode, out lineNumbers, out hitCounts)))
+                bool found = false;
+
+                using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                {
+                    found = instance.V8CpuProfileNode_GetHitLines(pNode, out lineNumbers, out hitCounts);
+                }
+
+                if (found)
                 {
                     var actualHitLineCount = Math.Min(lineNumbers.Length, hitCounts.Length);
                     if (actualHitLineCount > 0)
@@ -1294,7 +1597,13 @@ namespace Microsoft.ClearScript.V8.SplitProxy
                 for (var index = 0; index < childCount; index++)
                 {
                     var childIndex = index;
-                    var pChildNode = V8SplitProxyNative.InvokeNoThrow(instance => instance.V8CpuProfileNode_GetChildNode(pNode, childIndex));
+                    var pChildNode = Node.Ptr.Null;
+
+                    using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                    {
+                        pChildNode = instance.V8CpuProfileNode_GetChildNode(pNode, childIndex);
+                    }
+
                     if (pChildNode != Node.Ptr.Null)
                     {
                         childNodes.Add(CreateNode(hEntity, pChildNode));

--- a/ClearScript/V8/SplitProxy/V8SplitProxyManaged.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyManaged.cs
@@ -35,12 +35,18 @@ namespace Microsoft.ClearScript.V8.SplitProxy
 
         private static void ScheduleHostException(IntPtr pObject, Exception exception)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.HostException_Schedule(exception.GetBaseException().Message, V8ProxyHelpers.MarshalExceptionToScript(pObject, exception)));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.HostException_Schedule(exception.GetBaseException().Message, V8ProxyHelpers.MarshalExceptionToScript(pObject, exception));
+            }
         }
 
         private static void ScheduleHostException(Exception exception)
         {
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.HostException_Schedule(exception.GetBaseException().Message, ScriptEngine.Current?.MarshalToScript(exception)));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.HostException_Schedule(exception.GetBaseException().Message, ScriptEngine.Current?.MarshalToScript(exception));
+            }
         }
 
         private static uint GetMaxCacheSizeForCategory(DocumentCategory category)

--- a/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
+++ b/ClearScript/V8/SplitProxy/V8SplitProxyNative.cs
@@ -22,63 +22,19 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             }
         }
 
-        public static void Invoke(Action<IV8SplitProxyNative> action)
+        public static InvokeScope Invoke(out IV8SplitProxyNative instance)
         {
+            instance = V8SplitProxyNative.instance;
             var previousScheduledException = MiscHelpers.Exchange(ref V8SplitProxyManaged.ScheduledException, null);
             var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
-            try
-            {
-                action(instance);
-                ThrowScheduledException();
-            }
-            finally
-            {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
-                V8SplitProxyManaged.ScheduledException = previousScheduledException;
-            }
+            return new InvokeScope(previousScheduledException, previousMethodTable);
         }
 
-        public static T Invoke<T>(Func<IV8SplitProxyNative, T> func)
+        public static InvokeNoThrowScope InvokeNoThrow(out IV8SplitProxyNative instance)
         {
-            var previousScheduledException = MiscHelpers.Exchange(ref V8SplitProxyManaged.ScheduledException, null);
+            instance = V8SplitProxyNative.instance;
             var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
-            try
-            {
-                var result = func(instance);
-                ThrowScheduledException();
-                return result;
-            }
-            finally
-            {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
-                V8SplitProxyManaged.ScheduledException = previousScheduledException;
-            }
-        }
-
-        public static void InvokeNoThrow(Action<IV8SplitProxyNative> action)
-        {
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
-            try
-            {
-                action(instance);
-            }
-            finally
-            {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
-            }
-        }
-
-        public static T InvokeNoThrow<T>(Func<IV8SplitProxyNative, T> func)
-        {
-            var previousMethodTable = instance.V8SplitProxyManaged_SetMethodTable(V8SplitProxyManaged.MethodTable);
-            try
-            {
-                return func(instance);
-            }
-            finally
-            {
-                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
-            }
+            return new InvokeNoThrowScope(previousMethodTable);
         }
 
         private static void ThrowScheduledException()
@@ -86,6 +42,46 @@ namespace Microsoft.ClearScript.V8.SplitProxy
             if (V8SplitProxyManaged.ScheduledException != null)
             {
                 throw V8SplitProxyManaged.ScheduledException;
+            }
+        }
+
+        public readonly struct InvokeNoThrowScope : IDisposable
+        {
+            private readonly IntPtr previousMethodTable;
+
+            public InvokeNoThrowScope(IntPtr previousMethodTable)
+            {
+                this.previousMethodTable = previousMethodTable;
+            }
+
+            public void Dispose()
+            {
+                instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+            }
+        }
+
+        public readonly struct InvokeScope : IDisposable
+        {
+            private readonly Exception previousScheduledException;
+            private readonly IntPtr previousMethodTable;
+
+            public InvokeScope(Exception previousScheduledException, IntPtr previousMethodTable)
+            {
+                this.previousScheduledException = previousScheduledException;
+                this.previousMethodTable = previousMethodTable;
+            }
+
+            public void Dispose()
+            {
+                try
+                {
+                    ThrowScheduledException();
+                }
+                finally
+                {
+                    instance.V8SplitProxyManaged_SetMethodTable(previousMethodTable);
+                    V8SplitProxyManaged.ScheduledException = previousScheduledException;
+                }
             }
         }
     }

--- a/ClearScript/V8/SplitProxy/V8TestProxyImpl.cs
+++ b/ClearScript/V8/SplitProxy/V8TestProxyImpl.cs
@@ -9,13 +9,21 @@ namespace Microsoft.ClearScript.V8.SplitProxy
     {
         public override UIntPtr GetNativeDigest(string value)
         {
-            return V8SplitProxyNative.InvokeNoThrow(instance => instance.V8UnitTestSupport_GetTextDigest(value));
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                return instance.V8UnitTestSupport_GetTextDigest(value);
+            }
         }
 
         public override Statistics GetStatistics()
         {
             var statistics = new Statistics();
-            V8SplitProxyNative.InvokeNoThrow(instance => instance.V8UnitTestSupport_GetStatistics(out statistics.IsolateCount, out statistics.ContextCount));
+
+            using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+            {
+                instance.V8UnitTestSupport_GetStatistics(out statistics.IsolateCount, out statistics.ContextCount);
+            }
+
             return statistics;
         }
 

--- a/ClearScript/V8/V8Proxy.cs
+++ b/ClearScript/V8/V8Proxy.cs
@@ -169,8 +169,10 @@ namespace Microsoft.ClearScript.V8
 
                 fixed (byte* pBytes = bytes)
                 {
-                    var pICUData = (IntPtr)pBytes;
-                    V8SplitProxyNative.InvokeNoThrow(instance => instance.V8Environment_InitializeICU(pICUData, Convert.ToUInt32(length)));
+                    using (V8SplitProxyNative.InvokeNoThrow(out var instance))
+                    {
+                        instance.V8Environment_InitializeICU((IntPtr)pBytes, Convert.ToUInt32(length));
+                    }
                 }
             }
         }


### PR DESCRIPTION
This change gets rid of allocations in Invoke and InvokeNoThrow calls. Each allocation is not much, but these functions get called a lot, and it adds up.